### PR TITLE
Fix error handling in extract_data_from_api function

### DIFF
--- a/pipelines/datalake/extract_load/vitacare_api/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_api/tasks.py
@@ -87,8 +87,10 @@ def extract_data_from_api(
         env=environment,
     )
 
-    if response["status_code"] != 200:
-        raise ValueError(f"Failed to extract data from API: {response['status_code']}")
+    if response["status_code"] != 200 or "Request failed" in response["body"]:
+        raise ValueError(
+            f"Failed to extract data from API: {response['status_code']} - {response['body']}"
+        )
 
     requested_data = json.loads(response["body"])
 

--- a/pipelines/datalake/extract_load/vitacare_api/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_api/tasks.py
@@ -87,7 +87,7 @@ def extract_data_from_api(
         env=environment,
     )
 
-    if response["status_code"] != 200 or "Request failed" in response["body"]:
+    if response["status_code"] != 200:
         raise ValueError(
             f"Failed to extract data from API: {response['status_code']} - {response['body']}"
         )

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -478,13 +478,11 @@ def cloud_function_request(
             payload = response.json()
 
             if payload["status_code"] != 200:
-                message = f"[Target Endpoint] Request failed: {payload['status_code']} - {payload['body']}"
-                logger.error(message)
-                raise ValueError(message)
+                logger.error(f"[Target Endpoint] Request failed: {payload['status_code']} - {payload['body']}")
             else:
                 logger.info("[Target Endpoint] Request was successful")
 
-                return payload
+            return payload
 
         else:
             message = f"[Cloud Function] Request failed: {response.status_code} - {response.reason}"

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -478,7 +478,9 @@ def cloud_function_request(
             payload = response.json()
 
             if payload["status_code"] != 200:
-                logger.error(f"[Target Endpoint] Request failed: {payload['status_code']} - {payload['body']}")
+                logger.error(
+                    f"[Target Endpoint] Request failed: {payload['status_code']} - {payload['body']}"
+                )
             else:
                 logger.info("[Target Endpoint] Request was successful")
 

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -479,8 +479,8 @@ def cloud_function_request(
 
             if payload["status_code"] != 200:
                 message = f"[Target Endpoint] Request failed: {payload['status_code']} - {payload['body']}"
-                logger.info(message)
-                raise ENDRUN(state=Failed(message))
+                logger.error(message)
+                raise ValueError(message)
             else:
                 logger.info("[Target Endpoint] Request was successful")
 


### PR DESCRIPTION
@TanookiVerde este PR é para corrigir os casos onde a requisição era rejeitada na VitaCare (status 500), porém o retry não funcionava.
Isso ocorria devido ao tratamento de excessão da tarefa` cloud_function_request` em caso de status code != 200, no qual ele matava o flow. Na prática esse tratamento bypassava o retry da task ` extract_data_from_api`