### PR TITLE
feat: Increase page load timeout to 60 seconds

### DIFF
--- a/pipelines/datalake/extract_load/sisreg_web/sisreg/sisreg.py
+++ b/pipelines/datalake/extract_load/sisreg_web/sisreg/sisreg.py
@@ -41,7 +41,7 @@ class Sisreg:
         self._profile.set_preference("browser.helperApps.neverAsk.saveToDisk", "text/csv")
         self._options.profile = self._profile
         self.browser = webdriver.Firefox(options=self._options)
-        self.browser.set_page_load_timeout(30)
+        self.browser.set_page_load_timeout(60)
         self.user = user
         self.password = password
         self.download_path = download_path


### PR DESCRIPTION
The code change in `sisreg.py` increases the page load timeout from 30 seconds to 60 seconds. This allows more time for the page to load before timing out.