### PR TITLE
feat: Handle empty results in create_parameter_list

### DIFF
--- a/pipelines/datalake/extract_load/vitacare_api/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_api/tasks.py
@@ -299,7 +299,7 @@ def create_parameter_list(
     if area_programatica:
         results = results[results["area_programatica"] == area_programatica]
 
-    if results.empty:
+    if results.empty and is_routine:
         log("No data to process", level="error")
         raise FAIL("No data to process")
 


### PR DESCRIPTION
The code change in `tasks.py` adds a condition to check if the `results` dataframe is empty and if the `is_routine` flag is True. If both conditions are met, it logs an error message and raises an exception indicating that there is no data to process. This ensures that the code handles the scenario where there are no results to process in a reprocess  extraction.