### PR TITLE
feat: Add new table "contatos_unidades" to Google Sheets schedule

### DIFF
--- a/pipelines/datalake/extract_load/smsrio_mysql/constants.py
+++ b/pipelines/datalake/extract_load/smsrio_mysql/constants.py
@@ -18,5 +18,6 @@ class constants(Enum):
         "estoque": "estoque_posicao_almoxarifado_aps_dengue",
         "itens_estoque": "materiais_almoxarifado_dengue",
         "contatos_equipes": "equipe_contato",
+        "contatos_unidades": "estabelecimento_contato",
         "Unidades_OSA": "unidade_osa",
     }

--- a/pipelines/datalake/extract_load/smsrio_mysql/schedules.py
+++ b/pipelines/datalake/extract_load/smsrio_mysql/schedules.py
@@ -37,6 +37,13 @@ flow_parameters = [
         "rename_flow": True,
         "schema": "subpav_cnes",
     },
+    {
+        "table_id": "contatos_unidades",
+        "dataset_id": smsrio_constants.DATASET_ID.value,
+        "environment": "prod",
+        "rename_flow": True,
+        "schema": "subpav_cnes",
+    },
 ]
 
 

--- a/pipelines/datalake/extract_load/smsrio_mysql/tasks.py
+++ b/pipelines/datalake/extract_load/smsrio_mysql/tasks.py
@@ -38,7 +38,7 @@ def download_from_db(
     connection_string = f"{db_url}/{db_schema}"
 
     if db_table == "contatos_unidades":
-        query = f"SELECT u.cnes, c.* FROM {db_table} AS c LEFT JOIN unidades AS u ON c.unidade_id = u.id"
+        query = f"SELECT u.cnes, c.* FROM {db_table} AS c LEFT JOIN unidades AS u ON c.unidade_id = u.id"  # noqa: E501
     else:
         query = f"SELECT * FROM {db_table}"
 

--- a/pipelines/datalake/extract_load/smsrio_mysql/tasks.py
+++ b/pipelines/datalake/extract_load/smsrio_mysql/tasks.py
@@ -37,7 +37,10 @@ def download_from_db(
 
     connection_string = f"{db_url}/{db_schema}"
 
-    query = f"SELECT * FROM {db_table}"
+    if db_table == "contatos_unidades":
+        query = f"SELECT u.cnes, c.* FROM {db_table} AS c LEFT JOIN unidades AS u ON c.unidade_id = u.id"
+    else:
+        query = f"SELECT * FROM {db_table}"
 
     table = pd.read_sql(query, connection_string)
 


### PR DESCRIPTION
This commit adds a new table "contatos_unidades" to the Google Sheets extract and load pipeline. The schedule is added for the "prod" environment in the "brutos_sheets" dataset.