### PR TITLE
Fix: CSVs grandes estouram memória do Vitacare/GDrive

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
  - `poetry shell`
  - `poetry install`
 
+A versão do Poetry utilizada é 1.7.1. Se você instalou uma versão mais recente, você pode fazer downgrade com `poetry self update 1.7.1`.
+
 ### Etapa 2 - Configuração de Debugging
 - Crie pasta na raiz: `.vscode`
 - Dentro da pasta, crie um arquivo: `launch.json` e coloque o seguinte conteúdo dentro dele:
@@ -68,8 +70,8 @@ cases:
 - Sempre trabalhe com branchs `staging/<nome>`
 - Dê push e crie um Pull Request sem reviewer.
 - Cada commit nesta branch irá disparar as rotinas do Github que:
- - Verificam formatação
- - Fazem Deploy
- - Registram flows em staging (ambiente de testes)
+    - Verificam formatação
+    - Fazem Deploy
+    - Registram flows em staging (ambiente de testes)
 - Você acompanha o status destas rotinas na própria página do seu PR
 - Flows registrados aparecem no servidor Prefect. Eles podem ser rodados por lá

--- a/pipelines/datalake/extract_load/smsrio_mysql/flows.py
+++ b/pipelines/datalake/extract_load/smsrio_mysql/flows.py
@@ -11,9 +11,6 @@ from prefect.storage import GCS
 from prefeitura_rio.pipelines_utils.custom import Flow
 
 from pipelines.constants import constants
-from pipelines.datalake.extract_load.smsrio_mysql.constants import (
-    constants as smsrio_constants,
-)
 from pipelines.datalake.extract_load.smsrio_mysql.schedules import (
     smsrio_daily_update_schedule,
 )

--- a/pipelines/datalake/extract_load/vitacare_gdrive/flows.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/flows.py
@@ -12,7 +12,7 @@ from pipelines.datalake.extract_load.vitacare_gdrive.schedules import schedule
 from pipelines.datalake.extract_load.vitacare_gdrive.tasks import (
     find_all_file_names_from_pattern,
     get_most_recent_schema,
-    report_inadequency,
+    report_inadequacy,
     upload_consistent_files,
 )
 
@@ -49,7 +49,7 @@ with Flow(
         use_safe_download_file=unmapped(False),
     )
 
-    report_inadequency(
+    report_inadequacy(
         file_pattern=FILE_PATTERN,
         reports=reports,
     )

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -10,8 +10,8 @@ from pipelines.datalake.extract_load.vitacare_gdrive.constants import constants
 from pipelines.datalake.extract_load.vitacare_gdrive.utils import (
     download_file,
     fix_column_name,
+    format_bytes,
     get_file_size,
-    format_bytes
 )
 from pipelines.utils.credential_injector import authenticated_task as task
 from pipelines.utils.logger import log

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -117,6 +117,7 @@ def upload_consistent_files(
     # Experimentalmente:
     # - Arquivo de ~910 MB = 23 chunks de 100k linhas, ou 12 chunks de 200k linhas
     lines_per_chunk = 200_000
+    csv_reader = None
     try:
         # Cria um leitor pedaço a pedaço do arquivo CSV, mas ainda não carrega nada
         csv_reader = pd.read_csv(
@@ -125,6 +126,12 @@ def upload_consistent_files(
     except pd.errors.ParserError:
         log("Error reading CSV file", level="error")
         return pd.DataFrame()
+    except UnicodeDecodeError:
+        # Se tivemos erro de decoding, o arquivo não está em UTF-8;
+        # tenta com CP-1252, superset de ISO-8859-1/Latin-1
+        csv_reader = pd.read_csv(
+            csv_file, sep=detected_separator, dtype=str, encoding="cp1252", chunksize=lines_per_chunk
+        )
 
     # Colunas inesperadas que serão modificadas abaixo
     missing_columns = None

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -6,7 +6,10 @@ import pandas as pd
 from google.cloud import storage
 
 from pipelines.datalake.extract_load.vitacare_gdrive.constants import constants
-from pipelines.datalake.extract_load.vitacare_gdrive.utils import download_file, fix_column_name
+from pipelines.datalake.extract_load.vitacare_gdrive.utils import (
+    download_file,
+    fix_column_name,
+)
 from pipelines.utils.credential_injector import authenticated_task as task
 from pipelines.utils.logger import log
 from pipelines.utils.tasks import upload_df_to_datalake
@@ -54,7 +57,9 @@ def get_most_recent_schema(file_pattern: str, environment: str) -> pd.DataFrame:
     lines_per_chunk = 2
     try:
         # Cria um leitor do arquivo CSV
-        csv_reader = pd.read_csv(csv_file, sep=detected_separator, dtype=str, encoding="utf-8", chunksize=lines_per_chunk)
+        csv_reader = pd.read_csv(
+            csv_file, sep=detected_separator, dtype=str, encoding="utf-8", chunksize=lines_per_chunk
+        )
     except pd.errors.ParserError:
         log("Error reading CSV file", level="error")
         return []
@@ -68,7 +73,6 @@ def get_most_recent_schema(file_pattern: str, environment: str) -> pd.DataFrame:
     finally:
         # Garante que o file handle está fechado
         csv_file.close()
-
 
 
 @task(max_retries=3, retry_delay=timedelta(seconds=30))
@@ -87,7 +91,9 @@ def upload_consistent_files(
 
     # Download file
     try:
-        (csv_file, detected_separator, metadata_columns) = download_file(bucket, file_name, extra_safe=use_safe_download_file)
+        (csv_file, detected_separator, metadata_columns) = download_file(
+            bucket, file_name, extra_safe=use_safe_download_file
+        )
     except Exception as e:
         log(f"Error downloading file {file_name}: {e}", level="error")
         return {
@@ -118,7 +124,9 @@ def upload_consistent_files(
     lines_per_chunk = 200_000
     try:
         # Cria um leitor pedaço a pedaço do arquivo CSV, mas ainda não carrega nada
-        csv_reader = pd.read_csv(csv_file, sep=detected_separator, dtype=str, encoding="utf-8", chunksize=lines_per_chunk)
+        csv_reader = pd.read_csv(
+            csv_file, sep=detected_separator, dtype=str, encoding="utf-8", chunksize=lines_per_chunk
+        )
     except pd.errors.ParserError:
         log("Error reading CSV file", level="error")
         return pd.DataFrame()
@@ -176,7 +184,9 @@ def upload_consistent_files(
         else:
             # Não precisamos continuar iterando por todos os pedaços se
             # sabemos que o schema está inadequado
-            log(f"Inadequacy index ({inadequency_index:.2f}) over threshold ({inadequency_threshold:.2f}); aborting")
+            log(
+                f"Inadequacy index ({inadequency_index:.2f}) over threshold ({inadequency_threshold:.2f}); aborting"
+            )
             break
 
     log("Finished reading all chunks.")

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -115,7 +115,13 @@ def upload_consistent_files(
         return None
     else:
         file_size_mb = file_size_bytes / (1024 * 1024)
-        log(f"Downloaded file '{file_name}' has size {file_size_mb:.1f} MB")
+        file_size_kb = file_size_bytes / 1024
+        if file_size_mb >= 0.1:
+            log(f"Downloaded file '{file_name}' has size {file_size_mb:.1f} MB")
+        elif file_size_kb >= 0.1:
+            log(f"Downloaded file '{file_name}' has size {file_size_kb:.1f} KB")
+        else:
+            log(f"Downloaded file '{file_name}' has size {file_size_bytes} bytes")
     # Volta o ponteiro para o início
     csv_file.seek(0)
 

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -186,7 +186,7 @@ def upload_consistent_files(
             # sabemos que o schema está inadequado
             log(
                 f"Inadequacy index ({inadequency_index:.2f}) "
-                +"over threshold ({inadequency_threshold:.2f}); aborting"
+                + "over threshold ({inadequency_threshold:.2f}); aborting"
             )
             break
 

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -6,10 +6,7 @@ import pandas as pd
 from google.cloud import storage
 
 from pipelines.datalake.extract_load.vitacare_gdrive.constants import constants
-from pipelines.datalake.extract_load.vitacare_gdrive.utils import (
-    download_file,
-    safe_download_file,
-)
+from pipelines.datalake.extract_load.vitacare_gdrive.utils import download_file
 from pipelines.utils.credential_injector import authenticated_task as task
 from pipelines.utils.logger import log
 from pipelines.utils.tasks import upload_df_to_datalake
@@ -51,7 +48,7 @@ def get_most_recent_schema(file_pattern: str, environment: str) -> pd.DataFrame:
     most_recent_file = files[-1].name
     log(f"Most recent file: {most_recent_file}")
 
-    df = safe_download_file(bucket, most_recent_file)
+    df = download_file(bucket, most_recent_file, extra_safe=True)
     return df.columns.tolist()
 
 
@@ -71,10 +68,7 @@ def upload_consistent_files(
 
     # Download file
     try:
-        if use_safe_download_file:
-            df = safe_download_file(bucket, file_name)
-        else:
-            df = download_file(bucket, file_name)
+        df = download_file(bucket, file_name, extra_safe=use_safe_download_file)
     except Exception as e:
         log(f"Error downloading file {file_name}: {e}", level="error")
         return {

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -59,7 +59,11 @@ def get_most_recent_schema(file_pattern: str, environment: str) -> list:
 
     try:
         # Pega a primeira linha
-        first_line = csv_file.readline()
+        data = csv_file.readline()
+        first_line = data
+        if not type(data) == str:
+            detected_encoding = chardet.detect(data)["encoding"]
+            first_line = data.decode(detected_encoding)
         raw_columns = first_line.split(detected_separator)
         # Padroniza colunas
         columns = [fix_column_name(col) for col in raw_columns]

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -38,7 +38,7 @@ def find_all_file_names_from_pattern(file_pattern: str, environment: str):
 
 
 @task(max_retries=3, retry_delay=timedelta(seconds=30))
-def get_most_recent_schema(file_pattern: str, environment: str) -> pd.DataFrame:
+def get_most_recent_schema(file_pattern: str, environment: str) -> list:
     client = storage.Client()
     bucket_name = constants.GCS_BUCKET.value[environment]
     bucket = client.bucket(bucket_name)
@@ -59,9 +59,7 @@ def get_most_recent_schema(file_pattern: str, environment: str) -> pd.DataFrame:
 
     try:
         # Pega a primeira linha
-        data = csv_file.readline()
-        detected_encoding = chardet.detect(data)["encoding"]
-        first_line = data.decode(detected_encoding).strip()
+        first_line = csv_file.readline()
         raw_columns = first_line.split(detected_separator)
         # Padroniza colunas
         columns = [fix_column_name(col) for col in raw_columns]

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -185,7 +185,8 @@ def upload_consistent_files(
             # Não precisamos continuar iterando por todos os pedaços se
             # sabemos que o schema está inadequado
             log(
-                f"Inadequacy index ({inadequency_index:.2f}) over threshold ({inadequency_threshold:.2f}); aborting"
+                f"Inadequacy index ({inadequency_index:.2f}) "
+                +"over threshold ({inadequency_threshold:.2f}); aborting"
             )
             break
 

--- a/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/tasks.py
@@ -130,7 +130,11 @@ def upload_consistent_files(
         # Se tivemos erro de decoding, o arquivo não está em UTF-8;
         # tenta com CP-1252, superset de ISO-8859-1/Latin-1
         csv_reader = pd.read_csv(
-            csv_file, sep=detected_separator, dtype=str, encoding="cp1252", chunksize=lines_per_chunk
+            csv_file,
+            sep=detected_separator,
+            dtype=str,
+            encoding="cp1252",
+            chunksize=lines_per_chunk,
         )
 
     # Colunas inesperadas que serão modificadas abaixo

--- a/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
@@ -78,8 +78,8 @@ def fix_csv_file(csv_file, sep: str):
     for i in range(diff):
         columns.append(f"complemento_{i}")
 
-    new_first_line = sep.join(columns) + '\n'
-    new_csv_file.write(new_first_line.encode("utf-8")) # Melhor salvar como UTF-8
+    new_first_line = sep.join(columns) + "\n"
+    new_csv_file.write(new_first_line.encode("utf-8"))  # Melhor salvar como UTF-8
 
     csv_file.seek(0)
     csv_file.readline()
@@ -90,7 +90,7 @@ def fix_csv_file(csv_file, sep: str):
         new_line = line.strip()
         # Padroniza número de campos por linha
         diff = max_cols - (new_line.count(sep) + 1)
-        new_line += (sep * diff) + '\n'
+        new_line += (sep * diff) + "\n"
         new_csv_file.write(new_line.encode("utf-8"))
 
     # .close() mata o arquivo temporário inicial

--- a/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
@@ -138,8 +138,9 @@ def download_file(bucket, file_name, extra_safe=True):
 
     csv_file = None
     sep = None
-    # Caso o arquivo tenha >500 MB
-    if size_in_mb > 500:
+    MAX_SIZE_LOAD_TO_MEMORY_IN_MB = 250
+    # Caso o arquivo seja grande demais
+    if size_in_mb > MAX_SIZE_LOAD_TO_MEMORY_IN_MB:
         try:
             # Download do arquivo direto para disco
             csv_file = tempfile.TemporaryFile()
@@ -164,16 +165,15 @@ def download_file(bucket, file_name, extra_safe=True):
         if extra_safe:
             csv_file = fix_csv_file(csv_file, sep)
 
-    # Caso o arquivo tenha <= 500 MB
+    # Caso o arquivo seja pequeno o suficiente
     else:
         # Download do arquivo em memória
         data = blob.download_as_bytes()
         detected_encoding = chardet.detect(data)["encoding"]
         csv_text = data.decode(detected_encoding)
         sep = detect_separator(csv_text)
-        # Fix CSV
-        if extra_safe:
-            csv_text = fix_csv(csv_text, sep)
+        # Evita erros independentemente da flag se o arquivo for pequeno o suficiente
+        csv_text = fix_csv(csv_text, sep)
         csv_file = io.StringIO(csv_text)
 
     # Retorna tupla com:

--- a/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
@@ -22,7 +22,7 @@ def fix_csv(csv_text: str, sep: str) -> str:
 
     max_cols = len(columns)
     for line in other_lines:
-        line_columns = line.split(",") # FIXME: `sep` ao invés de ","? -Avellar
+        line_columns = line.split(",")  # FIXME: `sep` ao invés de ","? -Avellar
 
         if len(line_columns) > max_cols:
             max_cols = len(line_columns)
@@ -75,14 +75,14 @@ def download_file(bucket, file_name, extra_safe=True):
     # Arquivos muito grandes estouram a memória do processo (OOMKilled)
     # Então precisamos quebrar esse arquivo em partes
     # [Ref] https://pipelines.dados.rio/sms/flow-run/1b988b6c-44d6-419c-b11f-2feabbb11ce2?logs
-    
+
     csv_file = None
     sep = None
     # Caso o arquivo tenha >500 MB
     if size_in_mb > 500:
         # Gera nome do arquivo temporário
         timestamp = datetime.datetime.now(tz=pytz.timezone("America/Sao_Paulo")).isoformat()
-        file_name_no_slash = file_name.replace('/','-').replace('\\','-')
+        file_name_no_slash = file_name.replace("/", "-").replace("\\", "-")
         tmp_file_name = f"{timestamp}--{file_name_no_slash}"
 
         try:
@@ -92,10 +92,11 @@ def download_file(bucket, file_name, extra_safe=True):
         except Exception as e:
             log("error")
             log(e)
-        
+
         log("[download_file] Saved to local file: '/tmp/{tmp_file_name}'")
-        
-        from os import listdir #FIXME
+
+        from os import listdir  # FIXME
+
         log(listdir("/tmp"))
         # TODO: Está lidando corretamente com não-UTF-8? Precisa?
         csv_file = open(f"/tmp/{tmp_file_name}", "r")
@@ -104,9 +105,9 @@ def download_file(bucket, file_name, extra_safe=True):
         csv_file.seek(0)
         sep = detect_separator(first_line)
 
-        if extra_safe: 
-            #csv_text = fix_csv(csv_text, sep)
-            log("[!] 'Fix CSV' for big files is not implemented yet", level="warning") #FIXME
+        if extra_safe:
+            # csv_text = fix_csv(csv_text, sep)
+            log("[!] 'Fix CSV' for big files is not implemented yet", level="warning")  # FIXME
 
     # Caso o arquivo tenha <= 500 MB
     else:

--- a/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
@@ -137,13 +137,13 @@ def get_file_size(file_handle, seek_back_to=0) -> int:
 
 def format_bytes(bytes: int) -> str:
     gb = bytes / float(1024 * 1024 * 1024)
-    if gb > 0.1:
+    if gb > 0.5:
         return f"{gb:.1f} GB"
     mb = bytes / float(1024 * 1024)
-    if mb > 0.1:
+    if mb > 0.5:
         return f"{mb:.1f} MB"
     kb = bytes / float(1024)
-    if kb > 0.1:
+    if kb > 0.5:
         return f"{kb:.1f} kB"
     return f"{bytes:.1f} bytes"
 

--- a/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
@@ -3,7 +3,6 @@ import datetime
 import io
 
 import chardet
-import pandas as pd
 import pytz
 from tenacity import retry, stop_after_attempt, wait_fixed
 from unidecode import unidecode
@@ -111,8 +110,10 @@ def download_file(bucket, file_name, extra_safe=True):
             csv_text = fix_csv(csv_text, sep)
         csv_file = io.StringIO(csv_text)
 
-    # Retorna tupla com handle do buffer aberto do CSV (arquivo real ou StringIO, a depender do tamanho)
-    # separador detectado, e metadado a ser adicionado ao dataframe final
+    # Retorna tupla com:
+    # - Handle do buffer aberto do CSV (arquivo real ou StringIO, a depender do tamanho)
+    # - Separador detectado
+    # - Metadado a ser adicionado ao dataframe final
     return (
         csv_file,
         sep,

--- a/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
@@ -39,14 +39,8 @@ def fix_csv(csv_text: str, sep: str) -> str:
 
 
 def fix_column_name(column_name: str) -> str:
-    replace_from = [
-        [ "(", ")" ],
-        [ " ", "[", "]", "-", ".", ",", "/", "\\", "'", "\"" ]
-    ]
-    replace_to = [
-        "",
-        "_"
-    ]
+    replace_from = [["(", ")"], [" ", "[", "]", "-", ".", ",", "/", "\\", "'", '"']]
+    replace_to = ["", "_"]
     for from_list, to_char in zip(replace_from, replace_to):
         for from_char in from_list:
             column_name = column_name.replace(from_char, to_char)
@@ -125,6 +119,6 @@ def download_file(bucket, file_name, extra_safe=True):
         {
             "_source_file": file_name,
             "_extracted_at": blob.updated.astimezone(pytz.timezone("America/Sao_Paulo")),
-            "_loaded_at": datetime.datetime.now(tz=pytz.timezone("America/Sao_Paulo"))
-        }
+            "_loaded_at": datetime.datetime.now(tz=pytz.timezone("America/Sao_Paulo")),
+        },
     )

--- a/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
+++ b/pipelines/datalake/extract_load/vitacare_gdrive/utils.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import datetime
 import io
+import tempfile
 
 import chardet
 import pytz
-import tempfile
 from tenacity import retry, stop_after_attempt, wait_fixed
 from unidecode import unidecode
 
@@ -99,7 +99,10 @@ def download_file(bucket, file_name, extra_safe=True):
         if extra_safe:
             # FIXME
             # csv_text = fix_csv(csv_text, sep)
-            log("[!] 'Safe download' (fix_csv) for large (>500 MB) files is not implemented yet", level="warning")
+            log(
+                "[!] 'Safe download' (fix_csv) for large (>500 MB) files is not implemented yet",
+                level="warning",
+            )
 
     # Caso o arquivo tenha <= 500 MB
     else:


### PR DESCRIPTION
O pipeline Vitacare/GDrive baixa >100 CSVs de diferentes tamanhos, alguns de mais de 1GB. Atualmente, o pipeline falha por falta de memória – OOMKilled – porque os arquivos são baixados e mantidos em memória para serem transformados em pandas.DataFrames.
A ideia para solucionar é quebrar os arquivos grandes em pedaços e fazer upload de cada partição separadamente.