### PR TITLE
fix(datetime): ensure compatibility with date objects in get_datetime…

### DIFF
--- a/pipelines/utils/time.py
+++ b/pipelines/utils/time.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import date, timedelta, datetime
+from datetime import date, datetime, timedelta
 from typing import Optional
 
 import pandas as pd

--- a/pipelines/utils/time.py
+++ b/pipelines/utils/time.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 from typing import Optional
 
 import pandas as pd
@@ -70,6 +70,12 @@ def get_datetime_working_range(
     if timezone is None:
         timezone = "America/Sao_Paulo"
     tz = pytz.timezone(timezone)
+
+    if isinstance(start_datetime, date) and not isinstance(start_datetime, datetime):
+        start_datetime = datetime.combine(start_datetime, datetime.min.time())
+
+    if isinstance(end_datetime, date) and not isinstance(end_datetime, datetime):
+        end_datetime = datetime.combine(end_datetime, datetime.min.time())
 
     if start_datetime.tzinfo is None:
         start_datetime = tz.localize(start_datetime)


### PR DESCRIPTION
Ajuste na função get_datetime_working_range para lidar corretamente com entradas do tipo date, que não possuem o atributo .tzinfo. Isso estava causando erro. Adicionei uma verificação que converte date para datetime antes da aplicação de timezone, garantindo compatibilidade com os fluxos existentes sem alterar o comportamento original.