### PR TITLE
fix: GDrive → GCS OOM

### DIFF
--- a/pipelines/datalake/migrate/gdrive_to_gcs/flows.py
+++ b/pipelines/datalake/migrate/gdrive_to_gcs/flows.py
@@ -71,11 +71,11 @@ with Flow(
 # Storage and run configs
 migrate_gdrive_to_gcs.schedule = schedules
 migrate_gdrive_to_gcs.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
-migrate_gdrive_to_gcs.executor = LocalDaskExecutor(num_workers=5)
+migrate_gdrive_to_gcs.executor = LocalDaskExecutor(num_workers=3)
 migrate_gdrive_to_gcs.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value,
     labels=[
         constants.RJ_SMS_AGENT_LABEL.value,
     ],
-    memory_limit="10Gi",
+    memory_limit="13Gi",
 )

--- a/pipelines/datalake/migrate/gdrive_to_gcs/schedules.py
+++ b/pipelines/datalake/migrate/gdrive_to_gcs/schedules.py
@@ -34,16 +34,16 @@ flow_parameters = [
         "last_modified_date": "M-0",
         "rename_flow": True,
     },
-    # ===============================
-    # SIH
-    # ===============================
-    {
-        "folder_id": "1cOi0sZgjso-2Oiv93R62T060zd1XzeMu",
-        "bucket_name": "sih_gdrive",
-        "environment": "prod",
-        "last_modified_date": "M-0",
-        "rename_flow": True,
-    },
+    # # ===============================
+    # # SIH
+    # # ===============================
+    # {
+    #     "folder_id": "1cOi0sZgjso-2Oiv93R62T060zd1XzeMu",
+    #     "bucket_name": "sih_gdrive",
+    #     "environment": "prod",
+    #     "last_modified_date": "M-0",
+    #     "rename_flow": True,
+    # },
 ]
 
 


### PR DESCRIPTION
Tenta resolver o problema de Out of Memory no flow de extração do Drive para Cloud Storage limitando a 3 workers (era 5) e requisitando 13GB de RAM (era 10GB)

Também remove schedule de SIH que não está em uso atualmente
