### PR TITLE
[Diário Oficial da União] - Correção na extração do título do ato oficial

### DIFF
--- a/pipelines/datalake/extract_load/diario_oficial_uniao/flows.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/flows.py
@@ -39,7 +39,6 @@ with Flow(
     dou_infos = dou_extraction(date=date, dou_section=DOU_SECTION, max_workers=MAX_WORKERS)
     upload_to_datalake(dou_infos=dou_infos, environment=ENVIRONMENT, dataset=DATASET_ID)
 
-
 # Flow configs
 extract_diario_oficial_uniao.schedule = schedule
 extract_diario_oficial_uniao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/tasks.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/tasks.py
@@ -72,36 +72,28 @@ def dou_extraction(dou_section: int, max_workers: int, date: datetime) -> list:
         cards = driver.find_elements(by=By.CLASS_NAME, value="resultado")
 
         decree_links_to_process = []  # Lista para armazenar os links dos decretos
-        card_metadata = (
-            []
-        )  # Para armazenar title e outros dados que não dependem da requisição interna
 
+        # Pegando a url de cada ato na página de pesquisa
         for card in cards:
-            title = card.find_element(by=By.CLASS_NAME, value="title-marker")
-            info = card.find_element(
-                by=By.CLASS_NAME, value="breadcrumb-item.publication-info-marker"
-            )
             text_link = card.find_element(by=By.TAG_NAME, value="a")
-
             decree_links_to_process.append(text_link.get_attribute("href"))
-            card_metadata.append({"title": title.text, "info": info.text})
 
+        # Implementando extracao com concorrência
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             future_to_url = {
                 executor.submit(extract_decree_details, url): url for url in decree_links_to_process
             }
-
+    
             for i, future in enumerate(as_completed(future_to_url)):
                 url = future_to_url[future]
                 try:
                     decree_details = future.result()
-                    # Combinar os metadados do card com os detalhes do decreto
-                    combined_item = {**card_metadata[i], **decree_details}
-                    items.append(combined_item)
+                    items.append(decree_details)
                 except Exception as exc:
                     log(f"{url} gerou uma exceção: {exc}")
                     raise exc
-
+    
+        # Buscando o botão para a próxima página de pesquisa
         pagination_buttons = driver.find_elements(by=By.CLASS_NAME, value="pagination-button")
         next_btn = None
 
@@ -115,7 +107,7 @@ def dou_extraction(dou_section: int, max_workers: int, date: datetime) -> list:
             page_count += 1
             time.sleep(0.5)
         else:
-            break  # Chegou na última página da seção. Fim da extração
+            break  # Não há o botão para a próxima paǵina. Chegou na última página da seção, fim da extração
 
     driver.quit()
     log("✅ Extração finalizada.")

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/tasks.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/tasks.py
@@ -127,7 +127,7 @@ def upload_to_datalake(dou_infos: dict, dataset: str, environment: str) -> None:
 
     if dou_infos:
         rows = len(dou_infos)
-        df = pd.DataFrame(dou_infos)
+        df = pd.DataFrame(dou_infos) 
         df["extracted_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         log(f"Realizando upload de {rows} registros no datalake em {dataset}...")
 

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/tasks.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/tasks.py
@@ -83,7 +83,7 @@ def dou_extraction(dou_section: int, max_workers: int, date: datetime) -> list:
             future_to_url = {
                 executor.submit(extract_decree_details, url): url for url in decree_links_to_process
             }
-    
+
             for i, future in enumerate(as_completed(future_to_url)):
                 url = future_to_url[future]
                 try:
@@ -92,7 +92,7 @@ def dou_extraction(dou_section: int, max_workers: int, date: datetime) -> list:
                 except Exception as exc:
                     log(f"{url} gerou uma exceção: {exc}")
                     raise exc
-    
+
         # Buscando o botão para a próxima página de pesquisa
         pagination_buttons = driver.find_elements(by=By.CLASS_NAME, value="pagination-button")
         next_btn = None
@@ -127,7 +127,7 @@ def upload_to_datalake(dou_infos: dict, dataset: str, environment: str) -> None:
 
     if dou_infos:
         rows = len(dou_infos)
-        df = pd.DataFrame(dou_infos) 
+        df = pd.DataFrame(dou_infos)
         df["extracted_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         log(f"Realizando upload de {rows} registros no datalake em {dataset}...")
 

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
@@ -29,7 +29,8 @@ def extract_decree_details(text_link_href: str) -> dict:
         response = session.get(text_link_href)
         soup = BeautifulSoup(response.text, "html.parser")
 
-        decree_title = soup.find(clas_='portlet-title-text')
+        decree_title = soup.find(class_='portlet-title-text border-bottom-0')
+        print(decree_title.text) ###########3 tirar essa linha ###########
         decree_text = soup.find(class_="texto-dou")
         decree_date = soup.find(class_="publicado-dou-data")
         decree_edition = soup.find(class_="edicao-dou-data")
@@ -38,7 +39,7 @@ def extract_decree_details(text_link_href: str) -> dict:
         decree_agency = soup.find(class_="orgao-dou-data")
 
         return {
-            'title': decree_title if decree_title else "",
+            'title': decree_title.text if decree_title else "",
             "published_at": decree_date.text if decree_date else "",
             "edition": decree_edition.text if decree_edition else "",
             "section": decree_section.text if decree_section else "",

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
@@ -29,7 +29,7 @@ def extract_decree_details(text_link_href: str) -> dict:
         response = session.get(text_link_href)
         soup = BeautifulSoup(response.text, "html.parser")
 
-        decree_title = soup.find(class_='portlet-title-text border-bottom-0')
+        decree_title = soup.find(class_="portlet-title-text border-bottom-0")
         decree_text = soup.find(class_="texto-dou")
         decree_date = soup.find(class_="publicado-dou-data")
         decree_edition = soup.find(class_="edicao-dou-data")
@@ -38,7 +38,7 @@ def extract_decree_details(text_link_href: str) -> dict:
         decree_agency = soup.find(class_="orgao-dou-data")
 
         return {
-            'title': decree_title.text if decree_title else "",
+            "title": decree_title.text if decree_title else "",
             "published_at": decree_date.text if decree_date else "",
             "edition": decree_edition.text if decree_edition else "",
             "section": decree_section.text if decree_section else "",

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
@@ -29,6 +29,7 @@ def extract_decree_details(text_link_href: str) -> dict:
         response = session.get(text_link_href)
         soup = BeautifulSoup(response.text, "html.parser")
 
+        decree_title = soup.find(clas_='portlet-title-text')
         decree_text = soup.find(class_="texto-dou")
         decree_date = soup.find(class_="publicado-dou-data")
         decree_edition = soup.find(class_="edicao-dou-data")
@@ -37,6 +38,7 @@ def extract_decree_details(text_link_href: str) -> dict:
         decree_agency = soup.find(class_="orgao-dou-data")
 
         return {
+            'title': decree_title if decree_title else "",
             "published_at": decree_date.text if decree_date else "",
             "edition": decree_edition.text if decree_edition else "",
             "section": decree_section.text if decree_section else "",
@@ -50,15 +52,5 @@ def extract_decree_details(text_link_href: str) -> dict:
     except Exception as e:
         log(f"Erro durante a extração de {text_link_href}: {str(e)}")
         raise e
-        return {
-            "published_at": f"Erro: {str(e)}",
-            "edition": f"Erro: {str(e)}",
-            "section": f"Erro: {str(e)}",
-            "agency": f"Erro: {str(e)}",
-            "page": f"Erro: {str(e)}",
-            "text": f"Erro: {str(e)}",
-            "html": f"Erro: {str(e)}",
-            "url": text_link_href,
-        }
     finally:
         session.close()

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
@@ -30,7 +30,6 @@ def extract_decree_details(text_link_href: str) -> dict:
         soup = BeautifulSoup(response.text, "html.parser")
 
         decree_title = soup.find(class_='portlet-title-text border-bottom-0')
-        print(decree_title.text) ###########3 tirar essa linha ###########
         decree_text = soup.find(class_="texto-dou")
         decree_date = soup.find(class_="publicado-dou-data")
         decree_edition = soup.find(class_="edicao-dou-data")


### PR DESCRIPTION
Extração do título do ato oficial agora passa a ser feita na própria página do ato oficial e não mais na página de pesquisa.