### PR TITLE
[Diário Oficial da União] - Adição de novos campos na extração

### DIFF
--- a/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
@@ -31,13 +31,17 @@ def extract_decree_details(text_link_href: str) -> dict:
 
         decree_title = soup.find(class_="portlet-title-text border-bottom-0")
         decree_text = soup.find(class_="texto-dou")
-        decree_identifiers = soup.find_all(class_="identifica") # Título dentro do texto. Em alguns casos não é igual ao title
+        decree_identifiers = soup.find_all(
+            class_="identifica"
+        )  # Título dentro do texto. Em alguns casos não é igual ao title
         decree_date = soup.find(class_="publicado-dou-data")
         decree_edition = soup.find(class_="edicao-dou-data")
         decree_section = soup.find(class_="secao-dou")
         decree_page = soup.find(class_="secao-dou-data")
         decree_agency = soup.find(class_="orgao-dou-data")
-        decree_signatures = soup.find_all(class_="assina") # Quem assina o decreto (Caso haja assinatura)
+        decree_signatures = soup.find_all(
+            class_="assina"
+        )  # Quem assina o decreto (Caso haja assinatura)
 
         return {
             "title": decree_title.text if decree_title else "",

--- a/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
+++ b/pipelines/datalake/extract_load/diario_oficial_uniao/utils.py
@@ -31,14 +31,18 @@ def extract_decree_details(text_link_href: str) -> dict:
 
         decree_title = soup.find(class_="portlet-title-text border-bottom-0")
         decree_text = soup.find(class_="texto-dou")
+        decree_identifiers = soup.find_all(class_="identifica") # Título dentro do texto. Em alguns casos não é igual ao title
         decree_date = soup.find(class_="publicado-dou-data")
         decree_edition = soup.find(class_="edicao-dou-data")
         decree_section = soup.find(class_="secao-dou")
         decree_page = soup.find(class_="secao-dou-data")
         decree_agency = soup.find(class_="orgao-dou-data")
+        decree_signatures = soup.find_all(class_="assina") # Quem assina o decreto (Caso haja assinatura)
 
         return {
             "title": decree_title.text if decree_title else "",
+            "text_title": " ".join([identifier.text for identifier in decree_identifiers]),
+            "signatures": ";".join([signature.text for signature in decree_signatures]),
             "published_at": decree_date.text if decree_date else "",
             "edition": decree_edition.text if decree_edition else "",
             "section": decree_section.text if decree_section else "",


### PR DESCRIPTION
Adição da extração dos seguintes campos: 
- `text_title`: Título dentro do ato oficial (Em alguns casos é mais completo que o campo `title`) 
- `signatures`: Nome de quem assina o ato.