### PR TITLE
[SISCAN] Mudança na lógica de extração do flow do SISCAN

### DIFF
--- a/localrun.cases.yaml
+++ b/localrun.cases.yaml
@@ -379,17 +379,22 @@ cases:
       target_date: "D-1"
       dataset_id: "brutos_api_vitacare"
       table_id_prefix: "estoque_posicao"
-  - case_slug: "siscan_web_laudos"
+  - case_slug: "siscan_web_laudos_operator"
     flow_path: "pipelines.datalake.extract_load.siscan_web_laudos.flows"
-    flow_name: "sms_siscan_web"
+    flow_name: "sms_siscan_web_operator"
     params:
       environment: "dev"
-      data_inicial: "26/01/2025"
-      data_final: "26/01/2025"
+      data_inicial: "03/08/2025"
+      data_final: "03/08/2025"
       bq_dataset: "brutos_siscan_web"
       bq_table: "laudos"
-      dias_por_faixa: 15
-      formato_data: "%d/%m/%Y"
+  - case_slug: "siscan_web_laudos_manager"
+    flow_path: "pipelines.datalake.extract_load.siscan_web_laudos.flows"
+    flow_name: "sms_siscan_web_manager"
+    params:
+      environment: "dev"
+      relative_date: 'D-7'
+      range: 7
   - case_slug: "datalake-extract-subpav"
     flow_path: "pipelines.datalake.extract_load.subpav_mysql.flows"
     flow_name: "sms_dump_subpav"

--- a/pipelines/datalake/extract_load/siscan_web_laudos/constants.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/constants.py
@@ -4,7 +4,7 @@ Constantes
 """
 
 CONFIG = {
-    "flow_name": "SISREG WEB - Laudos",
+    "flow_name": "SISCAN - Laudos",
     "flow_owner": "matheusmiloski",
     "partition_column": "data_extracao",
     "source_format": "parquet",

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -27,9 +27,7 @@ from pipelines.datalake.utils.tasks import (
 )
 from pipelines.utils.credential_injector import (
     authenticated_create_flow_run as create_flow_run,
-)
-from pipelines.utils.credential_injector import (
-    authenticated_wait_for_flow_run as wait_for_flow_run,
+    authenticated_wait_for_flow_run as wait_for_flow_run
 )
 
 # internos
@@ -130,15 +128,15 @@ with Flow(
     )
 
     created_operator_runs = create_flow_run.map(
-        flow_name=unmapped("SUBGERAL - Extract & Load - SISCAN WEB - Laudos - Operator"),
+        flow_name=unmapped(sms_siscan_web_operator.name),
         project_name=unmapped(prefect_project_name),
         labels=unmapped(current_labels),
         parameters=operator_params,
         run_name=unmapped(None),
     )
 
-    wait_runs_task = wait_for_flow_run.map(
-        flow_name=unmapped(sms_siscan_web_operator.name),
+    wait_for_operator_runs = wait_for_flow_run.map(
+        flow_name=created_operator_runs,
         stream_states=unmapped(True),
         stream_logs=unmapped(True),
         raise_final_state=unmapped(True),
@@ -160,9 +158,7 @@ sms_siscan_web_manager.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 sms_siscan_web_manager.executor = LocalDaskExecutor(num_workers=6)
 sms_siscan_web_manager.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value,
-    labels=[
-        constants.RJ_SMS_AGENT_LABEL.value,
-    ],
+    labels=[constants.RJ_SMS_AGENT_LABEL.value],
     memory_limit="2Gi",
     memory_request="2Gi",
 )

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -121,7 +121,7 @@ with Flow(
     ###########################
     ENVIRONMENT = Parameter("environment", default="dev")
     RELATIVE_DATE = Parameter("relative_date", default="D-1")
-    DIAS_POR_FAIXA = Parameter("range", default=7)
+    DIAS_POR_FAIXA = Parameter("range", default=1)
     RENAME_FLOW = Parameter("rename_flow", default=True)
 
     with case(RENAME_FLOW, True):

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -27,6 +27,7 @@ from pipelines.datalake.utils.tasks import (
     rename_current_flow_run,
     upload_from_disk,
 )
+from pipelines.utils.time import parse_date_or_today
 from pipelines.utils.credential_injector import (
     authenticated_create_flow_run as create_flow_run,
 )
@@ -201,8 +202,8 @@ with Flow(
     # Flow
     ###########################
 
-    start_date = datetime.strptime(START_DATE, "%d/%m/%Y")
-    end_date = datetime.strptime(END_DATE, "%d/%m/%Y")
+    start_date = parse_date_or_today(START_DATE)
+    end_date = parse_date_or_today(END_DATE)
 
     # Gera as janelas de extração com base no interval
     windows = generate_extraction_windows(

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -17,8 +17,8 @@ from pipelines.datalake.extract_load.siscan_web_laudos.tasks import (
     build_operator_parameters,
     check_records,
     generate_extraction_windows,
+    parse_date,
     run_siscan_scraper,
-    parse_date
 )
 from pipelines.datalake.utils.tasks import (
     delete_file,

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -3,10 +3,9 @@
 Fluxo
 """
 
-# TO DO: PARALELIZAR
 from datetime import datetime
 
-from prefect import Parameter, unmapped
+from prefect import Parameter, unmapped, case
 from prefect.executors import LocalDaskExecutor
 from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
@@ -18,14 +17,15 @@ from pipelines.datalake.extract_load.siscan_web_laudos.tasks import (
     build_operator_parameters,
     generate_extraction_windows,
     run_siscan_scraper,
+    check_records
 )
 from pipelines.datalake.utils.tasks import (
     delete_file,
     extrair_fim,
     extrair_inicio,
-    gerar_faixas_de_data,
     prepare_df_from_disk,
     upload_from_disk,
+    rename_current_flow_run
 )
 from pipelines.utils.credential_injector import (
     authenticated_create_flow_run as create_flow_run,
@@ -39,7 +39,7 @@ from pipelines.utils.flow import Flow
 from pipelines.utils.prefect import get_current_flow_labels
 from pipelines.utils.state_handlers import handle_flow_state_change
 from pipelines.utils.tasks import get_project_name, get_secret_key
-from pipelines.utils.time import from_relative_date, get_datetime_working_range
+from pipelines.utils.time import from_relative_date
 
 with Flow(
     name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos (Operator)",
@@ -49,7 +49,10 @@ with Flow(
         constants.HERIAN_ID.value,
     ],
 ) as sms_siscan_web_operator:
-    # PARAMETROS AMBIENTE ---------------------------
+    
+    ###########################
+    # Parâmetros
+    ###########################
     ENVIRONMENT = Parameter("environment", default="dev")
 
     # PARAMETROS CREDENCIAIS ------------------------
@@ -68,6 +71,9 @@ with Flow(
     BQ_DATASET = Parameter("bq_dataset", default="brutos_siscan_web")
     BQ_TABLE = Parameter("bq_table", default="laudos")
 
+    ###########################
+    # Flow
+    ###########################
     # 1) Extrai e salva cada lote em disco, retorna caminho do parquet
     raw_files = run_siscan_scraper(
         email=user,
@@ -77,21 +83,24 @@ with Flow(
         output_dir=CONFIG["output_dir"],
     )
 
-    # 2) Prepara cada arquivo (lê e gera outro parquet)
-    prepared_files = prepare_df_from_disk(
-        file_path=raw_files,
-        flow_name=CONFIG["flow_name"],
-        flow_owner=CONFIG["flow_owner"],
-    )
+    any_records = check_records(file_path=raw_files)
+    
+    with case(task=any_records, value=True):
+        # 2) Prepara cada arquivo (lê e gera outro parquet)
+        prepared_files = prepare_df_from_disk(
+            file_path=raw_files,
+            flow_name=CONFIG["flow_name"],
+            flow_owner=CONFIG["flow_owner"],
+        )
 
-    # 3) Faz o upload lendo cada arquivo preparado do disco
-    uploads = upload_from_disk(
-        file_path=prepared_files,
-        table_id=BQ_TABLE,
-        dataset_id=BQ_DATASET,
-        partition_column=CONFIG["partition_column"],
-        source_format=CONFIG["source_format"],
-    )
+        # 3) Faz o upload lendo cada arquivo preparado do disco
+        uploads = upload_from_disk(
+            file_path=prepared_files,
+            table_id=BQ_TABLE,
+            dataset_id=BQ_DATASET,
+            partition_column=CONFIG["partition_column"],
+            source_format=CONFIG["source_format"],
+        )
 
     # 4) Exclui os arquivos após o upload
     delete_raw = delete_file(file_path=raw_files, upstream_tasks=[uploads])
@@ -106,23 +115,39 @@ with Flow(
         constants.HERIAN_ID.value,
     ],
 ) as sms_siscan_web_manager:
+    
+    ###########################
     # Parâmetros
+    ###########################
     ENVIRONMENT = Parameter("environment", default="dev")
     RELATIVE_DATE = Parameter("relative_date", default="D-1")
     DIAS_POR_FAIXA = Parameter("range", default=7)
-
+    RENAME_FLOW = Parameter('rename_flow', default=True)
+    
+    with case(RENAME_FLOW, True):
+        rename_current_flow_run(
+            environment=ENVIRONMENT,
+            relative_date=RELATIVE_DATE,
+            range=DIAS_POR_FAIXA,
+        )
+    
+    
+    ###########################
+    # Flow
+    ###########################
+    
+    # Gera data relativa e a data atual
     relative_date = from_relative_date(relative_date=RELATIVE_DATE)
     today = datetime.now()
 
+    # Gera as janelas de extração com base no interval
     windows = generate_extraction_windows(
         start_date=relative_date, end_date=today, interval=DIAS_POR_FAIXA
     )
     interval_starts = extrair_inicio.map(faixa=windows)
     interval_ends = extrair_fim.map(faixa=windows)
 
-    print(interval_starts)
-    print(interval_ends)
-
+    # Monta os parâmetros de cada operator
     prefect_project_name = get_project_name(environment=ENVIRONMENT)
     current_labels = get_current_flow_labels()
 
@@ -131,7 +156,8 @@ with Flow(
         end_dates=interval_ends,
         environment=ENVIRONMENT,
     )
-
+    
+    # Cria e espera a execução das flow runs
     created_operator_runs = create_flow_run.map(
         flow_name=unmapped(sms_siscan_web_operator.name),
         project_name=unmapped(prefect_project_name),
@@ -139,13 +165,15 @@ with Flow(
         parameters=operator_params,
         run_name=unmapped(None),
     )
-
+    
     wait_for_operator_runs = wait_for_flow_run.map(
         flow_run_id=created_operator_runs,
         stream_states=unmapped(True),
         stream_logs=unmapped(True),
         raise_final_state=unmapped(True),
     )
+    
+    
 
 # Configurações de execução
 sms_siscan_web_operator.executor = LocalDaskExecutor(num_workers=3)
@@ -156,8 +184,6 @@ sms_siscan_web_operator.run_config = KubernetesRun(
     memory_request=CONFIG["memory_request"],
     memory_limit=CONFIG["memory_limit"],
 )
-sms_siscan_web_operator.schedule = schedule
-
 
 sms_siscan_web_manager.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 sms_siscan_web_manager.executor = LocalDaskExecutor(num_workers=6)
@@ -167,3 +193,4 @@ sms_siscan_web_manager.run_config = KubernetesRun(
     memory_limit="2Gi",
     memory_request="2Gi",
 )
+sms_siscan_web_manager.schedule = schedule

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -16,8 +16,8 @@ from pipelines.datalake.extract_load.siscan_web_laudos.constants import CONFIG
 from pipelines.datalake.extract_load.siscan_web_laudos.schedules import schedule
 from pipelines.datalake.extract_load.siscan_web_laudos.tasks import (
     build_operator_parameters,
+    generate_extraction_windows,
     run_siscan_scraper,
-    generate_extraction_windows
 )
 from pipelines.datalake.utils.tasks import (
     delete_file,
@@ -114,16 +114,18 @@ with Flow(
     relative_date = from_relative_date(relative_date=RELATIVE_DATE)
     today = datetime.now()
 
-    windows = generate_extraction_windows(start_date=relative_date, end_date=today, interval=DIAS_POR_FAIXA)
+    windows = generate_extraction_windows(
+        start_date=relative_date, end_date=today, interval=DIAS_POR_FAIXA
+    )
     interval_starts = extrair_inicio.map(faixa=windows)
     interval_ends = extrair_fim.map(faixa=windows)
-    
+
     print(interval_starts)
     print(interval_ends)
-    
+
     prefect_project_name = get_project_name(environment=ENVIRONMENT)
     current_labels = get_current_flow_labels()
-    
+
     operator_params = build_operator_parameters(
         start_dates=interval_starts,
         end_dates=interval_ends,

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -27,7 +27,9 @@ from pipelines.datalake.utils.tasks import (
 )
 from pipelines.utils.credential_injector import (
     authenticated_create_flow_run as create_flow_run,
-    authenticated_wait_for_flow_run as wait_for_flow_run
+)
+from pipelines.utils.credential_injector import (
+    authenticated_wait_for_flow_run as wait_for_flow_run,
 )
 
 # internos

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -41,8 +41,6 @@ from pipelines.utils.state_handlers import handle_flow_state_change
 from pipelines.utils.tasks import get_project_name, get_secret_key
 from pipelines.utils.time import from_relative_date
 
-
-
 with Flow(
     name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos (Operator)",
     state_handlers=[handle_flow_state_change],
@@ -173,7 +171,7 @@ with Flow(
         stream_logs=unmapped(True),
         raise_final_state=unmapped(True),
     )
-    
+
 with Flow(
     name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos - Histórico",
     state_handlers=[handle_flow_state_change],
@@ -182,16 +180,16 @@ with Flow(
         constants.HERIAN_ID.value,
     ],
 ) as sms_siscan_web_historical:
-    
+
     ###########################
     # Parâmetros
     ###########################
     ENVIRONMENT = Parameter("environment", default="dev")
     DIAS_POR_FAIXA = Parameter("range", default=1)
     RENAME_FLOW = Parameter("rename_flow", default=True)
-    START_DATE = Parameter('start_date', default='01/01/2025')
-    END_DATE = Parameter('end_date', default='31/01/2025')
-    
+    START_DATE = Parameter("start_date", default="01/01/2025")
+    END_DATE = Parameter("end_date", default="31/01/2025")
+
     with case(RENAME_FLOW, True):
         rename_current_flow_run(
             environment=ENVIRONMENT,
@@ -202,9 +200,9 @@ with Flow(
     ###########################
     # Flow
     ###########################
-    
-    start_date = datetime.strptime(START_DATE, '%d/%m/%Y')
-    end_date = datetime.strptime(END_DATE, '%d/%m/%Y')
+
+    start_date = datetime.strptime(START_DATE, "%d/%m/%Y")
+    end_date = datetime.strptime(END_DATE, "%d/%m/%Y")
 
     # Gera as janelas de extração com base no interval
     windows = generate_extraction_windows(

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -13,7 +13,8 @@ from prefect.storage import GCS
 from pipelines.constants import constants
 from pipelines.datalake.extract_load.siscan_web_laudos.constants import CONFIG
 from pipelines.datalake.extract_load.siscan_web_laudos.schedules import schedule
-from pipelines.datalake.extract_load.siscan_web_laudos.tasks import run_siscan_scraper
+from pipelines.datalake.extract_load.siscan_web_laudos.tasks import run_siscan_scraper, build_operator_parameters
+from pipelines.utils.time import from_relative_date, get_datetime_working_range
 from pipelines.datalake.utils.tasks import (
     delete_file,
     extrair_fim,
@@ -23,18 +24,29 @@ from pipelines.datalake.utils.tasks import (
     upload_from_disk,
 )
 
+from pipelines.utils.flow import Flow
+from pipelines.utils.prefect import get_current_flow_labels
+from pipelines.utils.state_handlers import handle_flow_state_change
+from pipelines.utils.tasks import get_project_name, get_secret_key
+from pipelines.utils.time import from_relative_date, get_datetime_working_range
+from pipelines.utils.credential_injector import (
+    authenticated_create_flow_run as create_flow_run,
+    authenticated_wait_for_flow_run as wait_for_flow_run,
+)
 # internos
 from pipelines.utils.flow import Flow
 from pipelines.utils.state_handlers import handle_flow_state_change
 from pipelines.utils.tasks import get_secret_key
 
 with Flow(
-    name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos",
+    name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos (Operator)",
     state_handlers=[handle_flow_state_change],
     owners=[
         constants.MATHEUS_ID.value,
+        constants.HERIAN_ID.value,
     ],
-) as sms_siscan_web:
+    
+) as sms_siscan_web_operator:
     # PARAMETROS AMBIENTE ---------------------------
     ENVIRONMENT = Parameter("environment", default="dev")
 
@@ -50,60 +62,113 @@ with Flow(
     DATA_INICIAL = Parameter("data_inicial", default="01/01/2025")
     DATA_FINAL = Parameter("data_final", default="31/01/2025")
 
-    # PARAMETROS PARA DEFINIR TAMANHO DOS LOTES ------
-    DIAS_POR_FAIXA = Parameter("dias_por_faixa", default=10)
-    FORMATO_DATA = Parameter("formato_data", default="%d/%m/%Y")
-
     # PARAMETROS BQ ----------------------------------
     BQ_DATASET = Parameter("bq_dataset", default="brutos_siscan_web")
     BQ_TABLE = Parameter("bq_table", default="laudos")
-
-    faixas = gerar_faixas_de_data(
-        data_inicial=DATA_INICIAL,
-        data_final=DATA_FINAL,
-        dias_por_faixa=DIAS_POR_FAIXA,
-        date_format=FORMATO_DATA,
-    )
-
-    inicio_faixas = extrair_inicio.map(faixa=faixas)
-    fim_faixas = extrair_fim.map(faixa=faixas)
-
+     
     # 1) Extrai e salva cada lote em disco, retorna caminho do parquet
-    raw_files = run_siscan_scraper.map(
-        email=unmapped(user),
-        password=unmapped(password),
-        start_date=inicio_faixas,
-        end_date=fim_faixas,
-        output_dir=unmapped(CONFIG["output_dir"]),
+    raw_files = run_siscan_scraper(
+        email=user,
+        password=password,
+        start_date=DATA_INICIAL,
+        end_date=DATA_FINAL,
+        output_dir=CONFIG["output_dir"],
     )
 
     # 2) Prepara cada arquivo (lê e gera outro parquet)
-    prepared_files = prepare_df_from_disk.map(
+    prepared_files = prepare_df_from_disk(
         file_path=raw_files,
-        flow_name=unmapped(CONFIG["flow_name"]),
-        flow_owner=unmapped(CONFIG["flow_owner"]),
+        flow_name=CONFIG["flow_name"],
+        flow_owner=CONFIG["flow_owner"],
     )
 
     # 3) Faz o upload lendo cada arquivo preparado do disco
-    uploads = upload_from_disk.map(
+    uploads = upload_from_disk(
         file_path=prepared_files,
-        table_id=unmapped(BQ_TABLE),
-        dataset_id=unmapped(BQ_DATASET),
-        partition_column=unmapped(CONFIG["partition_column"]),
-        source_format=unmapped(CONFIG["source_format"]),
+        table_id=BQ_TABLE,
+        dataset_id=BQ_DATASET,
+        partition_column=CONFIG["partition_column"],
+        source_format=CONFIG["source_format"],
     )
 
     # 4) Exclui os arquivos após o upload
-    delete_raw = delete_file.map(file_path=raw_files, upstream_tasks=[uploads])
-    delete_prepared = delete_file.map(file_path=prepared_files, upstream_tasks=[uploads])
+    delete_raw = delete_file(file_path=raw_files, upstream_tasks=[uploads])
+    delete_prepared = delete_file(file_path=prepared_files, upstream_tasks=[uploads])
+
+
+with Flow(
+    name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos (Manager)",
+    state_handlers=[handle_flow_state_change],
+    owners=[
+        constants.MATHEUS_ID.value,
+        constants.HERIAN_ID.value,
+    ],
+) as sms_siscan_web_manager:
+    # Parâmetros
+    ENVIRONMENT = Parameter("environment", default="dev")
+    RELATIVE_DATE = Parameter("relative_date", default="D-1")
+    BQ_DATASET = Parameter("bq_dataset", default="brutos_siscan_web")
+    BQ_TABLE = Parameter("bq_table", default="laudos")
+    DIAS_POR_FAIXA = Parameter("dias_por_faixa", default=7)
+    FORMATO_DATA = Parameter("formato_data", default="%d/%m/%Y")
+        
+    start_date, end_date = get_datetime_working_range(start_datetime=RELATIVE_DATE)
+    
+    faixas = gerar_faixas_de_data(
+        data_inicial=start_date,
+        data_final=end_date,
+        dias_por_faixa=DIAS_POR_FAIXA,
+        date_format=FORMATO_DATA,
+    )
+    
+    inicio_faixas = extrair_inicio.map(faixas)
+    fim_faixas = extrair_fim.map(faixas)
+    prefect_project_name = get_project_name(environment=ENVIRONMENT)
+    current_labels = get_current_flow_labels()
+    
+    operator_params = build_operator_parameters(
+        start_dates = inicio_faixas,
+        end_dates = fim_faixas,
+        bq_dataset = BQ_DATASET,
+        bq_table = BQ_TABLE,
+        environment = ENVIRONMENT,
+    )
+    
+    created_operator_runs = create_flow_run.map(
+        flow_name = unmapped('SUBGERAL - Extract & Load - SISCAN WEB - Laudos - Operator'),
+        project_name = unmapped(prefect_project_name),
+        labels = unmapped(current_labels),
+        parameters = operator_params,
+        run_name = unmapped(None)
+    )
+
+    wait_runs_task = wait_for_flow_run.map(
+        flow_name = unmapped(sms_siscan_web_operator.name),
+        stream_states=unmapped(True),
+        stream_logs=unmapped(True),
+        raise_final_state=unmapped(True),
+    )
 
 # Configurações de execução
-sms_siscan_web.executor = LocalDaskExecutor(num_workers=3)
-sms_siscan_web.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
-sms_siscan_web.run_config = KubernetesRun(
+sms_siscan_web_operator.executor = LocalDaskExecutor(num_workers=3)
+sms_siscan_web_operator.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+sms_siscan_web_operator.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value,
     labels=[constants.RJ_SMS_AGENT_LABEL.value],
     memory_request=CONFIG["memory_request"],
     memory_limit=CONFIG["memory_limit"],
 )
-sms_siscan_web.schedule = schedule
+sms_siscan_web_operator.schedule = schedule
+
+
+sms_siscan_web_manager.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+sms_siscan_web_manager.executor = LocalDaskExecutor(num_workers=6)
+sms_siscan_web_manager.run_config = KubernetesRun(
+    image=constants.DOCKER_IMAGE.value,
+    labels=[
+        constants.RJ_SMS_AGENT_LABEL.value,
+    ],
+    memory_limit="2Gi",
+    memory_request="2Gi",
+)
+

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -193,8 +193,9 @@ with Flow(
 
     with case(RENAME_FLOW, True):
         rename_current_flow_run(
-            environment=ENVIRONMENT,
-            relative_date=RELATIVE_DATE,
+            environment=ENVIRONMENT,   
+            start_date=START_DATE,
+            end_date=END_DATE,
             range=DIAS_POR_FAIXA,
         )
 

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -109,7 +109,8 @@ with Flow(
     RELATIVE_DATE = Parameter("relative_date", default="D-1")
     DIAS_POR_FAIXA = Parameter("range", default=7)
 
-    start_date, end_date = get_datetime_working_range(start_datetime=RELATIVE_DATE)
+    data_filter = from_relative_date(RELATIVE_DATE)
+    start_date, end_date = get_datetime_working_range(start_datetime=data_filter)
 
     faixas = gerar_faixas_de_data(
         data_inicial=start_date,

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -27,7 +27,6 @@ from pipelines.datalake.utils.tasks import (
     rename_current_flow_run,
     upload_from_disk,
 )
-from pipelines.utils.time import parse_date_or_today
 from pipelines.utils.credential_injector import (
     authenticated_create_flow_run as create_flow_run,
 )
@@ -40,7 +39,7 @@ from pipelines.utils.flow import Flow
 from pipelines.utils.prefect import get_current_flow_labels
 from pipelines.utils.state_handlers import handle_flow_state_change
 from pipelines.utils.tasks import get_project_name, get_secret_key
-from pipelines.utils.time import from_relative_date
+from pipelines.utils.time import from_relative_date, parse_date_or_today
 
 with Flow(
     name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos (Operator)",

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -17,8 +17,8 @@ from pipelines.datalake.extract_load.siscan_web_laudos.tasks import (
     build_operator_parameters,
     check_records,
     generate_extraction_windows,
-    parse_date,
     run_siscan_scraper,
+    parse_date
 )
 from pipelines.datalake.utils.tasks import (
     delete_file,
@@ -202,8 +202,8 @@ with Flow(
     # Flow
     ###########################
 
-    start_date = parse_date(START_DATE)
-    end_date = parse_date(END_DATE)
+    start_date = parse_date(date=START_DATE)
+    end_date = parse_date(date=END_DATE)
 
     # Gera as janelas de extração com base no interval
     windows = generate_extraction_windows(

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -109,7 +109,7 @@ with Flow(
     RELATIVE_DATE = Parameter("relative_date", default="D-1")
     DIAS_POR_FAIXA = Parameter("range", default=7)
 
-    data_filter = from_relative_date(RELATIVE_DATE)
+    data_filter = from_relative_date(relative_date=RELATIVE_DATE)
     start_date, end_date = get_datetime_working_range(start_datetime=data_filter)
 
     faixas = gerar_faixas_de_data(

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -18,6 +18,7 @@ from pipelines.datalake.extract_load.siscan_web_laudos.tasks import (
     check_records,
     generate_extraction_windows,
     run_siscan_scraper,
+    parse_date
 )
 from pipelines.datalake.utils.tasks import (
     delete_file,
@@ -39,7 +40,7 @@ from pipelines.utils.flow import Flow
 from pipelines.utils.prefect import get_current_flow_labels
 from pipelines.utils.state_handlers import handle_flow_state_change
 from pipelines.utils.tasks import get_project_name, get_secret_key
-from pipelines.utils.time import from_relative_date, parse_date_or_today
+from pipelines.utils.time import from_relative_date
 
 with Flow(
     name="SUBGERAL - Extract & Load - SISCAN WEB - Laudos (Operator)",
@@ -201,8 +202,8 @@ with Flow(
     # Flow
     ###########################
 
-    start_date = parse_date_or_today(START_DATE)
-    end_date = parse_date_or_today(END_DATE)
+    start_date = parse_date(START_DATE)
+    end_date = parse_date(END_DATE)
 
     # Gera as janelas de extração com base no interval
     windows = generate_extraction_windows(

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -138,7 +138,7 @@ with Flow(
     )
 
     wait_for_operator_runs = wait_for_flow_run.map(
-        flow_name=created_operator_runs,
+        flow_run_id=created_operator_runs,
         stream_states=unmapped(True),
         stream_logs=unmapped(True),
         raise_final_state=unmapped(True),

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -193,7 +193,7 @@ with Flow(
 
     with case(RENAME_FLOW, True):
         rename_current_flow_run(
-            environment=ENVIRONMENT,   
+            environment=ENVIRONMENT,
             start_date=START_DATE,
             end_date=END_DATE,
             range=DIAS_POR_FAIXA,

--- a/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/flows.py
@@ -107,10 +107,7 @@ with Flow(
     # Parâmetros
     ENVIRONMENT = Parameter("environment", default="dev")
     RELATIVE_DATE = Parameter("relative_date", default="D-1")
-    BQ_DATASET = Parameter("bq_dataset", default="brutos_siscan_web")
-    BQ_TABLE = Parameter("bq_table", default="laudos")
-    DIAS_POR_FAIXA = Parameter("dias_por_faixa", default=7)
-    FORMATO_DATA = Parameter("formato_data", default="%d/%m/%Y")
+    DIAS_POR_FAIXA = Parameter("range", default=7)
 
     start_date, end_date = get_datetime_working_range(start_datetime=RELATIVE_DATE)
 
@@ -118,19 +115,16 @@ with Flow(
         data_inicial=start_date,
         data_final=end_date,
         dias_por_faixa=DIAS_POR_FAIXA,
-        date_format=FORMATO_DATA,
     )
 
-    inicio_faixas = extrair_inicio.map(faixas)
-    fim_faixas = extrair_fim.map(faixas)
+    inicio_faixas = extrair_inicio.map(faixa=faixas)
+    fim_faixas = extrair_fim.map(faixa=faixas)
     prefect_project_name = get_project_name(environment=ENVIRONMENT)
     current_labels = get_current_flow_labels()
 
     operator_params = build_operator_parameters(
         start_dates=inicio_faixas,
         end_dates=fim_faixas,
-        bq_dataset=BQ_DATASET,
-        bq_table=BQ_TABLE,
         environment=ENVIRONMENT,
     )
 

--- a/pipelines/datalake/extract_load/siscan_web_laudos/schedules.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/schedules.py
@@ -1,10 +1,10 @@
-# -- coding: utf-8 --
+# -*- coding: utf-8 -*-
 """
 Agendamentos
 """
 
 # Geral
-from datetime import datetime, timedelta, time
+from datetime import datetime, time, timedelta
 
 import pytz
 
@@ -26,16 +26,8 @@ operator_flow_parameters = [
 ]
 
 manager_flow_parameters = [
-    {
-        "environment": "prod",
-        "relative_date": "M-1",
-        "range": 1
-    }, 
-    {
-        "environment": "prod",
-        "relative_date": "D-1",
-        "range": 1
-    }
+    {"environment": "prod", "relative_date": "M-1", "range": 1},
+    {"environment": "prod", "relative_date": "D-1", "range": 1},
 ]
 
 monthly_manager_clock = generate_dump_api_schedules(
@@ -61,6 +53,5 @@ daily_manager_clock = generate_dump_api_schedules(
 manager_clocks = daily_manager_clock + monthly_manager_clock
 
 schedule = Schedule(
-    clocks=untuple_clocks(manager_clocks), 
-    filters=[filters.between_times(time(19), time(23))]
+    clocks=untuple_clocks(manager_clocks), filters=[filters.between_times(time(19), time(23))]
 )

--- a/pipelines/datalake/extract_load/siscan_web_laudos/scraper/driver.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/scraper/driver.py
@@ -44,7 +44,7 @@ def init_firefox(*, headless: bool | None = None) -> Firefox:
     opcoes.set_preference("browser.download.dir", str(DIRETORIO_DOWNLOADS))
     opcoes.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/json")
 
-    servico = FirefoxService(GeckoDriverManager().install())
+    servico = FirefoxService()
     driver = Firefox(service=servico, options=opcoes)
     driver.set_page_load_timeout(TEMPO_ESPERA_PADRAO)
     LOGGER.info("Driver Firefox inicializado (headless=%s).", headless)

--- a/pipelines/datalake/extract_load/siscan_web_laudos/scraper/patients.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/scraper/patients.py
@@ -4,7 +4,6 @@
 """Iteração sobre pacientes e extração de laudos detalhados (v2.0)."""
 
 from __future__ import annotations
-
 from datetime import datetime
 from typing import Any, Dict, List, Set
 

--- a/pipelines/datalake/extract_load/siscan_web_laudos/scraper/patients.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/scraper/patients.py
@@ -4,6 +4,7 @@
 """Iteração sobre pacientes e extração de laudos detalhados (v2.0)."""
 
 from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Dict, List, Set
 

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -58,6 +58,32 @@ def run_siscan_scraper(
         log(f"Erro durante a execução do scraper: {e}", level="error")
         raise
 
+@task
+def generate_extraction_windows(start_date:datetime, end_date:datetime , interval: int) -> list: 
+    """Gera janelas de extração de dados com base em um intervalo de datas e um intervalo de dias.
+    
+    Args:
+        start_date (datetime): Data inicial
+        end_date (datetime): Data final
+        interval (int): Número de dias por janela
+
+    Returns:
+        list: Lista de tuplas com as datas de início e fim de cada janela
+    """
+    intervals = []
+
+    while start_date <= end_date:
+        end_interval = start_date + timedelta(days=interval - 1)
+        if end_interval > end_date:
+            end_interval = end_date
+        intervals.append((
+            start_date.strftime("%d/%m/%Y"),
+            end_interval.strftime("%d/%m/%Y")
+        ))
+        start_date = end_interval + timedelta(days=1)
+    
+    return intervals
+
 
 @task
 def build_operator_parameters(start_dates: tuple, end_dates: tuple, environment: str = "dev"):

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -116,6 +116,7 @@ def build_operator_parameters(
         for start, end in zip(start_dates, end_dates)
     ]
 
+
 @task
 def parse_date(date: str) -> datetime:
     return datetime.strptime(date, "%d/%m/%Y")

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -38,7 +38,7 @@ def run_siscan_scraper(
         log(f"Iniciando coleta de dados do SISCaN de {start_date} a {end_date}.")
 
         pacientes = run_scraper(
-            email=email, password=password, start_date=start_date, end_date=end_date, headless=True
+            email=email, password=password, start_date=start_date, end_date=end_date, headless=False
         )
         df = pd.DataFrame(pacientes)
 
@@ -57,3 +57,16 @@ def run_siscan_scraper(
     except Exception as e:
         log(f"Erro durante a execução do scraper: {e}", level="error")
         raise
+
+@task
+def build_operator_parameters(start_dates: tuple, end_dates: tuple, bq_table: str, bq_dataset: str, environment: str = 'dev'):
+    return [
+        {
+            "environment": environment,
+            "data_inicial": start,
+            "data_final": end,
+            "bq_dataset": bq_dataset,
+            "bq_table": bq_table,
+        }
+        for start, end in zip(start_dates, end_dates)
+    ]

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -58,8 +58,11 @@ def run_siscan_scraper(
         log(f"Erro durante a execução do scraper: {e}", level="error")
         raise
 
+
 @task
-def build_operator_parameters(start_dates: tuple, end_dates: tuple, bq_table: str, bq_dataset: str, environment: str = 'dev'):
+def build_operator_parameters(
+    start_dates: tuple, end_dates: tuple, bq_table: str, bq_dataset: str, environment: str = "dev"
+):
     return [
         {
             "environment": environment,

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -60,14 +60,8 @@ def run_siscan_scraper(
 
 
 @task
-def build_operator_parameters(
-    start_dates: tuple, end_dates: tuple, environment: str = "dev"
-):
+def build_operator_parameters(start_dates: tuple, end_dates: tuple, environment: str = "dev"):
     return [
-        {
-            "environment": environment,
-            "data_inicial": start,
-            "data_final": end
-        }
+        {"environment": environment, "data_inicial": start, "data_final": end}
         for start, end in zip(start_dates, end_dates)
     ]

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -115,3 +115,7 @@ def build_operator_parameters(
         {"environment": environment, "data_inicial": start, "data_final": end}
         for start, end in zip(start_dates, end_dates)
     ]
+
+@task
+def parse_date(date: str) -> datetime:
+    return datetime.strptime(date, "%d/%m/%Y")

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -58,10 +58,11 @@ def run_siscan_scraper(
         log(f"Erro durante a execução do scraper: {e}", level="error")
         raise
 
+
 @task
-def generate_extraction_windows(start_date:datetime, end_date:datetime , interval: int) -> list: 
+def generate_extraction_windows(start_date: datetime, end_date: datetime, interval: int) -> list:
     """Gera janelas de extração de dados com base em um intervalo de datas e um intervalo de dias.
-    
+
     Args:
         start_date (datetime): Data inicial
         end_date (datetime): Data final
@@ -76,12 +77,9 @@ def generate_extraction_windows(start_date:datetime, end_date:datetime , interva
         end_interval = start_date + timedelta(days=interval - 1)
         if end_interval > end_date:
             end_interval = end_date
-        intervals.append((
-            start_date.strftime("%d/%m/%Y"),
-            end_interval.strftime("%d/%m/%Y")
-        ))
+        intervals.append((start_date.strftime("%d/%m/%Y"), end_interval.strftime("%d/%m/%Y")))
         start_date = end_interval + timedelta(days=1)
-    
+
     return intervals
 
 

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -38,7 +38,7 @@ def run_siscan_scraper(
         log(f"Iniciando coleta de dados do SISCaN de {start_date} a {end_date}.")
 
         pacientes = run_scraper(
-            email=email, password=password, start_date=start_date, end_date=end_date, headless=False
+            email=email, password=password, start_date=start_date, end_date=end_date, headless=True
         )
         df = pd.DataFrame(pacientes)
 

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -61,15 +61,13 @@ def run_siscan_scraper(
 
 @task
 def build_operator_parameters(
-    start_dates: tuple, end_dates: tuple, bq_table: str, bq_dataset: str, environment: str = "dev"
+    start_dates: tuple, end_dates: tuple, environment: str = "dev"
 ):
     return [
         {
             "environment": environment,
             "data_inicial": start,
-            "data_final": end,
-            "bq_dataset": bq_dataset,
-            "bq_table": bq_table,
+            "data_final": end
         }
         for start, end in zip(start_dates, end_dates)
     ]

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -13,8 +13,8 @@ import pandas as pd
 from prefeitura_rio.pipelines_utils.logging import log
 
 from pipelines.datalake.extract_load.siscan_web_laudos.scraper import run_scraper
-from pipelines.utils.credential_injector import authenticated_task as task
 from pipelines.datalake.utils.tasks import delete_file
+from pipelines.utils.credential_injector import authenticated_task as task
 
 
 @task(max_retries=5, retry_delay=timedelta(minutes=3))
@@ -63,11 +63,11 @@ def run_siscan_scraper(
 @task
 def check_records(file_path: str) -> bool:
     df = pd.read_parquet(file_path)
-    
+
     if df.empty:
-        log('⚠️ Não há registros para processar.')
+        log("⚠️ Não há registros para processar.")
         delete_file(file_path=file_path)
-        log('⚠️ O arquivo vazio foi excluído.')
+        log("⚠️ O arquivo vazio foi excluído.")
         return False
 
     return True
@@ -98,16 +98,18 @@ def generate_extraction_windows(start_date: datetime, end_date: datetime, interv
 
 
 @task
-def build_operator_parameters(start_dates: tuple, end_dates: tuple, environment: str = "dev") -> list:
+def build_operator_parameters(
+    start_dates: tuple, end_dates: tuple, environment: str = "dev"
+) -> list:
     """Gera lista de parâmetros para o(s) operator(s).
-    
+
     Args:
         start_dates (tuple): Data inicial da extração
         end_dates (tuple): Data final da extração
         environment (str, optional): Ambiente de execução. Defaults to 'dev'.
 
     Returns:
-        List[dict]: Lista com os parâmetros do(s) operator(s). 
+        List[dict]: Lista com os parâmetros do(s) operator(s).
     """
     return [
         {"environment": environment, "data_inicial": start, "data_final": end}

--- a/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
+++ b/pipelines/datalake/extract_load/siscan_web_laudos/tasks.py
@@ -66,7 +66,7 @@ def check_records(file_path: str) -> bool:
 
     if df.empty:
         log("⚠️ Não há registros para processar.")
-        delete_file(file_path=file_path)
+        delete_file.run(file_path=file_path)
         log("⚠️ O arquivo vazio foi excluído.")
         return False
 

--- a/pipelines/flows.py
+++ b/pipelines/flows.py
@@ -22,7 +22,6 @@ from pipelines.datalake.extract_load.medilab_api.flows import *
 from pipelines.datalake.extract_load.minhasaude_mongodb.flows import *
 from pipelines.datalake.extract_load.relational_db.flows import *
 from pipelines.datalake.extract_load.ser_metabase.flows import *
-
 from pipelines.datalake.extract_load.siscan_web_laudos.flows import *
 from pipelines.datalake.extract_load.sisreg_api.flows import *
 from pipelines.datalake.extract_load.sisreg_web.flows import *

--- a/pipelines/flows.py
+++ b/pipelines/flows.py
@@ -23,7 +23,7 @@ from pipelines.datalake.extract_load.minhasaude_mongodb.flows import *
 from pipelines.datalake.extract_load.relational_db.flows import *
 from pipelines.datalake.extract_load.ser_metabase.flows import *
 
-# from pipelines.datalake.extract_load.siscan_web_laudos.flows import * -- Precisa de ajustes
+from pipelines.datalake.extract_load.siscan_web_laudos.flows import *
 from pipelines.datalake.extract_load.sisreg_api.flows import *
 from pipelines.datalake.extract_load.sisreg_web.flows import *
 from pipelines.datalake.extract_load.sisreg_web_v2.flows import *


### PR DESCRIPTION
As alterações feitas neste PR buscam otimizar a lógica de extração do SISCAN adicionando um flow manager para controle de extrações rotineiras. 

A lógica atual conta com um agendamento diário que faz a extração do dia anterior (D-1) e um agendamento mensal que faz a coleta de dados dos últimos 30 dias (M-1), essa lógica busca cobrir laudos de exames que tiveram alteração após o dia da publicação. 

Além disso, também há o tratamento para extrações sem registros (normalmente para finais de semana). 