### PR TITLE
[SICLOM] - Extração de dados da API

### DIFF
--- a/localrun.cases.yaml
+++ b/localrun.cases.yaml
@@ -555,17 +555,18 @@ cases:
       html_body_path: "mail_templates/gerencia_cancer/gerencia_cancer.html"
       plain_body_path: "mail_templates/gerencia_cancer/gerencia_cancer.txt"
 
-  - case_slug: cdi_extract_sheets_individual_2025
-    flow_path: pipelines.datalake.extract_load.google_sheets.flows
-    flow_name: sms_dump_url
+  - case_slug: siclom_extraction
+    flow_path: pipelines.datalake.extract_load.siclom_api.flows
+    flow_name: siclom_period_extraction
     params:
       environment: "dev"
-      csv_delimiter: ";"
-      dataset_id: "brutos_cdi"
-      gsheets_sheet_name: "Controle de Demandas - Equipe Individual"
-      table_id: "equipe_individual_2025"
-      url: "https://docs.google.com/spreadsheets/d/1JirkDMgtYUIiJ7z5Zcxnn3sCUAneWwVfgT6u-M3QHE8"
-      url_type: "google_sheet"
+      endpoint: "/tratamentoperiodo/"
+      annual: false
+      year: null
+      month: null
+      extraction_range: null
+      dataset_id: "brutos_siclom_api"
+      table_id: "carga_viral_teste"
 
   - case_slug: cdi_extract_sheets_individual_2026
     flow_path: pipelines.datalake.extract_load.google_sheets.flows

--- a/pipelines/datalake/extract_load/siclom_api/constants.py
+++ b/pipelines/datalake/extract_load/siclom_api/constants.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=C0103
+
+from enum import Enum
+
+
+class constants(Enum):
+    INFISICAL_PATH = "/siclom"
+    APY_KEY = "X-API-KEY"
+    URL = "URL"

--- a/pipelines/datalake/extract_load/siclom_api/flows.py
+++ b/pipelines/datalake/extract_load/siclom_api/flows.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+from prefect import Parameter, case, unmapped
+from prefect.executors import LocalDaskExecutor
+from prefect.run_configs import KubernetesRun
+from prefect.storage import GCS
+
+from pipelines.constants import constants
+from pipelines.datalake.extract_load.siclom_api.constants import (
+    constants as siclom_constants,
+)
+from pipelines.datalake.extract_load.siclom_api.schedules import schedule
+from pipelines.datalake.extract_load.siclom_api.tasks import (
+    format_month,
+    generate_formated_months,
+    get_siclom_period_data,
+)
+from pipelines.datalake.utils.tasks import rename_current_flow_run
+from pipelines.utils.flow import Flow
+from pipelines.utils.state_handlers import handle_flow_state_change
+from pipelines.utils.tasks import get_secret_key, upload_df_to_datalake
+
+with Flow(
+    name="DataLake - Extração e Carga de Dados - SICLOM API",
+    state_handlers=[handle_flow_state_change],
+    owners=[
+        constants.HERIAN_ID.value,
+    ],
+) as siclom_period_extraction:
+    """
+    Os parametros annual, month, year e extraction_range foram pensados para permitir flexibilidade nas extrações.
+
+    Por exemplo, se quisermos extrair os dados de um mês específico, basta preencher os campos month e year,
+    deixando annual como False. Se quisermos extrair os dados de um ano específico, basta preencher o campo year
+    e annual como True, o campo month será ignorado.
+
+    O campo extraction_range serve para definir o intervalo de anos a ser extraído a partir do ano de referência,
+    ou seja, se year for 2024 e extraction_range for 5, serão extraídos os dados de 2024, 2023, 2022, 2021 e 2020.
+    """
+    ENVIRONMENT = Parameter("environment", default="dev", required=True)
+    ENDPOINT = Parameter("endpoint", required=True)
+    ANNUAL = Parameter("annual", default=False, required=True)
+    MONTH = Parameter("month", default=None, required=False)
+    YEAR = Parameter("year", default=None, required=False)
+    EXTRACTION_RANGE = Parameter("extraction_range", default=5, required=False)
+    DATASET_ID = Parameter("dataset_id", default="brutos_siclom_api", required=True)
+    TABLE_ID = Parameter("table_id", default="", required=True)
+
+    BASE_URL = get_secret_key(
+        secret_path=siclom_constants.INFISICAL_PATH.value,
+        secret_name=siclom_constants.URL.value,
+        environment=ENVIRONMENT,
+    )
+
+    API_KEY = get_secret_key(
+        secret_path=siclom_constants.INFISICAL_PATH.value,
+        secret_name=siclom_constants.APY_KEY.value,
+        environment=ENVIRONMENT,
+    )
+
+    rename_current_flow_run(table=TABLE_ID, annual=ANNUAL, environment=ENVIRONMENT)
+
+    with case(ANNUAL, False):
+        # 1 - Formata a string do mês
+        formated_month = format_month(month=MONTH, year=YEAR)
+
+        # 2 - Faz a requisição na API do SICLOM
+        month_data = get_siclom_period_data(
+            base_url=BASE_URL, endpoint=ENDPOINT, api_key=API_KEY, period=formated_month
+        )
+
+        # 3 - Carrega os dados no datalake
+        uploaded_data = upload_df_to_datalake(
+            df=month_data,
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            if_exists="append",
+            partition_column="extracted_at",
+            csv_delimiter=",",
+        )
+
+    with case(ANNUAL, True):
+        # 1 - Gera as strings numéricas de cada mês formatadas
+        formated_periods = generate_formated_months(reference_year=YEAR, interval=EXTRACTION_RANGE)
+
+        # 2 - Faz as requisições na API do SICLOM
+        months_data = get_siclom_period_data.map(
+            base_url=unmapped(BASE_URL),
+            period=formated_periods,
+            endpoint=unmapped(ENDPOINT),
+            api_key=unmapped(API_KEY),
+        )
+
+        # 3 - Carrega os dados no datalake
+        uploaded_data = upload_df_to_datalake.map(
+            df=months_data,
+            dataset_id=unmapped(DATASET_ID),
+            table_id=unmapped(TABLE_ID),
+            if_exists=unmapped("append"),
+            partition_column=unmapped("extracted_at"),
+            csv_delimiter=unmapped(","),
+        )
+
+siclom_period_extraction.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+siclom_period_extraction.executor = LocalDaskExecutor(num_workers=2)
+siclom_period_extraction.run_config = KubernetesRun(
+    image=constants.DOCKER_IMAGE.value,
+    labels=[constants.RJ_SMS_AGENT_LABEL.value],
+    memory_limit="4Gi",
+    memory_request="2Gi",
+)
+siclom_period_extraction.schedule = schedule

--- a/pipelines/datalake/extract_load/siclom_api/schedules.py
+++ b/pipelines/datalake/extract_load/siclom_api/schedules.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+
+import pytz
+from prefect.schedules import Schedule
+
+from pipelines.constants import constants
+from pipelines.utils.schedules import generate_dump_api_schedules, untuple_clocks
+
+# Atualmente só para referência
+flow_parameters = [
+    {
+        "environment": "prod",
+        "endpoint": "/mostracargacd4periodo/",
+        "annual": False,
+        "year": None,
+        "month": None,
+        "extraction_range": None,
+        "dataset_id": "brutos_siclom_api",
+        "table_id": "carga_cd4",
+    },
+    {
+        "environment": "prod",
+        "endpoint": "/mostracargaviralperiodo/",
+        "annual": False,
+        "year": None,
+        "month": None,
+        "extraction_range": None,
+        "dataset_id": "brutos_siclom_api",
+        "table_id": "carga_viral",
+    },
+    {
+        "environment": "prod",
+        "endpoint": "/tratamentoperiodo/",
+        "annual": False,
+        "year": None,
+        "month": None,
+        "extraction_range": None,
+        "dataset_id": "brutos_siclom_api",
+        "table_id": "tratamento",
+    },
+    {
+        "environment": "prod",
+        "endpoint": "/resultadopepperiodo/",
+        "annual": False,
+        "year": None,
+        "month": None,
+        "extraction_range": None,
+        "dataset_id": "brutos_siclom_api",
+        "table_id": "pep",
+    },
+    {
+        "environment": "prod",
+        "endpoint": "/resultadoprepperiodo/",
+        "annual": False,
+        "year": None,
+        "month": None,
+        "extraction_range": None,
+        "dataset_id": "brutos_siclom_api",
+        "table_id": "prep",
+    },
+]
+
+clocks = generate_dump_api_schedules(
+    interval=timedelta(days=7),
+    # 2026-03-21 é um sábado
+    start_date=datetime(
+        year=2026, month=3, day=21, hour=3, minute=0, tzinfo=pytz.timezone("America/Sao_Paulo")
+    ),
+    labels=[
+        constants.RJ_SMS_AGENT_LABEL.value,
+    ],
+    flow_run_parameters=flow_parameters,
+    runs_interval_minutes=2,
+)
+
+schedule = Schedule(clocks=untuple_clocks(clocks))

--- a/pipelines/datalake/extract_load/siclom_api/tasks.py
+++ b/pipelines/datalake/extract_load/siclom_api/tasks.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+import pytz
+import requests
+from google.cloud import bigquery
+from pandas import DataFrame, DateOffset
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from pipelines.datalake.extract_load.siclom_api.constants import constants
+from pipelines.utils.credential_injector import authenticated_task as task
+from pipelines.utils.logger import log
+
+
+def make_request(url: str, headers: dict) -> requests.Response | None:
+    """Faz requisição para uma API utilizando o método GET."""
+    session = requests.Session()
+    retries = Retry(total=2, backoff_factor=1, status_forcelist=[502, 503, 504, 104])
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+    try:
+        response = session.get(url=url, headers=headers)
+    except requests.exceptions.RequestException:
+        return None
+    return response
+
+
+@task
+def format_month(month: str, year: str) -> str:
+    """Formata string numérica referente ao mês-ano.
+
+    Se a execução estiver ocorrendo no início do mês (dia < 7), a função irá formatar o mês-ano para o mês anterior,
+    garantindo que o mês anterior foi completamente extraído e carregado no datalake, evitando possíveis lacunas nos dados.
+    """
+
+    if not month and not year:
+        current_date = datetime.now(pytz.timezone("America/Sao_Paulo"))
+
+        # Se for início do mês, a extração será para o mês anterior
+        # Em testes realizados, no começo do mês a API do SICLOM ainda não possui os dados do mês corrente,
+        # mas já possui os dados do mês anterior completamente disponíveis, por isso essa lógica foi implementada
+        # para garantir a extração dos dados mais recentes possíveis.
+        if current_date.day <= 7:
+            target_month = current_date + DateOffset(months=-1)
+            target_date = target_month.strftime("%m/%Y")
+        else:
+            target_date = current_date.strftime("%m/%Y")
+
+        return target_date
+
+    if int(month) > 12:
+        raise Exception(msg="Mês inválido.")
+    return f"{str(month).zfill(2)}/{year}"
+
+
+@task
+def generate_formated_months(reference_year: str, interval) -> list[str]:
+    """Gera strings numéricas formatadas referente aos meses para extrações anuais
+    de forma regressiva a partir do ano de referência, seguindo o formato MM/YYYY.
+    """
+
+    periods = []
+    for year in range(reference_year, reference_year - interval, -1):
+        periods.extend([f"{str(month).zfill(2)}/{year}" for month in range(1, 13)])
+    log(periods)
+    return periods
+
+
+@task
+def get_siclom_period_data(base_url: str, endpoint: str, api_key: str, period: str) -> DataFrame:
+    """Faz a requisição para a API do SICLOM utilizando a busca por mês e ano."""
+    log(f"Buscando dados de {period}...")
+
+    headers = {"Accept": "application/json", "X-API-KEY": api_key}
+    if endpoint != "/resultadoprepperiodo/":
+        url = f"{base_url}{endpoint}{period}"
+
+        response = make_request(url=url, headers=headers)
+        if response and response.status_code == 200:
+            data = response.json()["resultado"]
+            df = DataFrame(data)
+            df["extracted_at"] = datetime.now(pytz.timezone("America/Sao_Paulo")).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+
+            log("✅ Extração realizada com sucesso!")
+            return df
+        else:
+            response.raise_for_status()
+    else:
+        return get_siclom_prep_data.run(endpoint=endpoint, api_key=api_key, period=period)
+
+
+@task
+def get_siclom_prep_data(endpoint: str, api_key: str, period: str) -> DataFrame:
+    """Faz a requisição para a API do SICLOM utilizando a busca por mês e ano para dados de PREP.
+    Este endpoint é paginado e possui uma lógica de extração diferente dos demais, por isso foi necessário criar uma task específica para ele.
+    """
+    log(f"Buscando dados de PREP de {period}...")
+
+    headers = {"Accept": "application/json", "X-API-KEY": api_key}
+
+    base_url = constants.BASE_URL.value
+    url = f"{base_url}{endpoint}{period}?page=1&numItemsPerPage=50"
+    extracted_data = []
+    response = make_request(url=url, headers=headers)
+
+    if not response:
+        return DataFrame()
+    else:
+        payload = response.json()
+        if "resultado" not in payload:
+            log("Nenhum dado retornado para o período solicitado.")
+            return DataFrame()
+        page = payload["resultado"]
+        extracted_data.extend(page["items"])
+        next = page["next"]
+        log("Iniciando extração por paginação...")
+        while next:
+            log(f'Extraindo página {page["current"]}/{page["pageCount"]}...')
+            url = f"{base_url}{endpoint}{period}?page={next}&numItemsPerPage=50"
+            response = make_request(url=url, headers=headers)
+            if not response or response.status_code != 200:
+                break
+            payload = response.json()
+            if "resultado" not in payload:
+                break
+            page = payload["resultado"]
+            extracted_data.extend(page["items"])
+            if "next" in page:
+                next = page["next"]
+            else:
+                break
+    df = DataFrame(extracted_data)
+    df["extracted_at"] = datetime.now(pytz.timezone("America/Sao_Paulo")).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    return df
+
+
+# Após a implementação do endpoint para obter dados por período na API do SICLOM,
+# as seguintes tasks perderam o sentido em serem utilizadas, mas preferi mante-las
+# para possíveis necessidades futuras.
+@task
+def get_patient_data(environment: str, table_id, batch: int, retry: bool):
+    """
+    Obtém os CPFs a serem consultados na API do SICLOM e divide em lotes.
+
+    Parâmetros:
+        - `batch`: Tamanho de cada lote de CPFs a ser gerado para requisições paralelizadas
+        - `table_id`: Tabela de destino dos dados.
+        - `retry`: Utilizada para obter CPFs que não estão na tabela fim. Essa flag pode ser utilizada
+        tanto para obter novos CPFs ou para possíveis CPFs que tiveram erro durante a extração pela API.
+    """
+
+    log("Obtendo dados dos pacientes de interesse...")
+    client = bigquery.Client()
+
+    if retry:
+        sql = f"""
+                with 
+                    pacientes_hci as (
+                        select distinct paciente_cpf as cpf
+                        from `rj-sms.saude_historico_clinico.episodio_assistencial`
+                        where `condicoes`[SAFE_OFFSET(0)].id  in ('B200','B204','B222','B217','B20','B205',
+                        'B238','Z21','B211','B213','Z830','B208','Z114','B231','B203','B201','Z206','B212',
+                        'B221','B24','B209','B220','B219','B210','B230','B207','B21','B22','F024','B232',
+                        'B23','B206','Z717','R75','B218','B202','B227')
+                    )
+                select distinct cpf 
+                from pacientes_hci 
+                where cpf not in (select cpf from rj-sms.brutos_siclom_api.{table_id})       
+        """
+    else:
+        sql = """
+                select distinct paciente_cpf as cpf
+                from `rj-sms.saude_historico_clinico.episodio_assistencial`
+                where `condicoes`[SAFE_OFFSET(0)].id  in ('B200','B204','B222','B217','B20','B205','B238','Z21',
+                        'B211','B213','Z830','B208','Z114','B231','B203','B201','Z206','B212','B221',
+                        'B24','B209','B220','B219','B210','B230','B207','B21','B22','F024','B232',
+                        'B23','B206','Z717','R75','B218','B202','B227')
+        """
+
+    df = client.query_and_wait(sql).to_dataframe()
+    cpf_list = df["cpf"].to_list()
+    chunks = [cpf_list[i : i + batch] for i in range(0, len(cpf_list), batch)]
+
+    return chunks
+
+
+@task
+def fetch_siclom_data(cpf_batch: list, endpoint: str, api_key: str):
+    """
+    Faz a requisição para a API do SICLOM utilizando a busca por CPF.
+    """
+    log("Buscando dados do Siclom para o lote de CPFs...")
+
+    base_url = constants.BASE_URL.value
+    url = f"{base_url}{endpoint}"
+
+    headers = {"Accept": "application/json", "X-API-KEY": api_key}
+
+    patients_data = []
+
+    for cpf in cpf_batch:
+        try:
+            response = make_request(url=url + cpf, headers=headers)
+            if not response:
+                continue  # Atualmente a API retorna 500 quando o CPF não é encontrado.
+            if response.status_code == 200:
+                patients_data.extend(response.json()["resultado"])
+        except TypeError:
+            # Casos que por algum motivo o CPF é considerado None
+            continue
+        except Exception as e:
+            raise e
+    if patients_data:
+        df = DataFrame(patients_data)
+        df["extracted_at"] = datetime.now(pytz.timezone("America/Sao_Paulo")).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    else:
+        df = DataFrame()
+
+    return df

--- a/pipelines/flows.py
+++ b/pipelines/flows.py
@@ -28,6 +28,7 @@ from pipelines.datalake.extract_load.prontuario_gcs.flows import *
 from pipelines.datalake.extract_load.rnds_historico.flows import *
 from pipelines.datalake.extract_load.relational_db.flows import *
 from pipelines.datalake.extract_load.ser_metabase.flows import *
+from pipelines.datalake.extract_load.siclom_api.flows import *
 from pipelines.datalake.extract_load.siscan_web_laudos.flows import *
 from pipelines.datalake.extract_load.sisreg_api.flows import *
 from pipelines.datalake.extract_load.sisreg_web.flows import *


### PR DESCRIPTION
# Contexto
O time da SAP entrou com a Secretaria de Vigilância em Saúde e Ambiente (SVSA) do Ministério da Saúde para obter os dados da base do SICLOM/SISCEL e pediu suporte do CIT para implementar a extração e o carregamento destes dados.

## Objetivo
Este PR adiciona o flow de extração do SICLOM utilizando o API disponibilizada pela SVSA.

## Sobre a Fonte de Dados
A extração é feita a partir da API criada exclusivamente para utilização nossa. Na primeira versão, a API necessitava do CPF de cada paciente para obter os dados, este fluxo foi posto de lado devido a grande quantidade de tempo que demandava (cerca de 64 mil CPFs com tempo de resposta de ~0.5s por requisição). Dessa forma, uma segunda versão foi solicitada e atualmente conseguimos extrair os registros de pacientes do estado do Rio de Janeiro por mes/ano.
Até o momento, ainda não foi apresentada uma documentação para uso da API, mas temos acessos aos seguintes endpoints:

- /mostracargacd4periodo/06/2025
- /mostracargaviralperiodo/06/2025
- /resultadoprepperiodo/06/2025
- /tratamentoperiodo/06/2025
- /resultadopepperiodo/06/2025

# Pipeline

## Parametros
- `ENVIRONMENT`: Ambiente de carregamento dos dados.
- `ENDPOINT`: Endpoint que será extraído.
- `ANNUAL`: Flag que indica se a extração é anual.
- `YEAR`: Ano que será extraído
- `MONTH`: Mês que será extraído (Se o ANNUAL for True este parâmetro será desconsiderado)
- `EXTRACTION_RANGE`: Número inteiro que indica a quantidade de anos que será extraída. É considerado apenas quando a extração for anual.
- `DATASET_ID`: Nome do dataset onde será carregado os dados.
- `TABLE_ID`: Nome da tabela onde será carregado os dados. 

## Fluxo de extração 
O fluxo não é complexo, mas existem alguns pontos que valem ser esclarecidos.

O primeiro ponto é que existe uma uma bifurcação que diferencia a extração anual da extração por mês. Na extração anual, é gerado uma lista de datas no formato "mes/ano" para todos os meses de todos os anos (dentro do intervalo definido pelo parâmetro extraction_range e year) e em seguida é feita a requisição no endpoint da tabela desejada de forma concorrente (utilizando o `.map`).

<img width="1029" height="480" alt="image_1773328745387_0" src="https://github.com/user-attachments/assets/d8a8a371-ec2d-4b45-9162-2738a32326b8" />

Há uma particularidade em relação ao endpoint `resultadoprepperiodo/mes/ano`, ele é o único endpoint paginado, por isso a lógica da extração é diferente dos demais endpoints.




